### PR TITLE
Depend on R >= 3.4

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,7 +21,6 @@ jobs:
           - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest, r: '3.6'}
           - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.3', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.4', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.5', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.6', cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ URL: https://github.com/2DegreesInvesting/r2dii.analysis
 BugReports: 
     https://github.com/2DegreesInvesting/r2dii.analysis/issues
 Depends:
-    R (>= 2.10)
+    R (>= 3.4)
 Imports: 
     dplyr,
     glue,


### PR DESCRIPTION
Upstream dependencies support R >= 3.4 (e.g. r2dii.match). This is
reasonable as we are now on R 4.0 and we check on R release, oldrel
(3.6), 3.5, and 3.4.