### PR TITLE
87 bugfix regional scenario targets

### DIFF
--- a/R/target_market_share_company.R
+++ b/R/target_market_share_company.R
@@ -33,7 +33,7 @@
 target_market_share_company <- function(data) {
   stopifnot(is.data.frame(data))
 
-  by_company <- c("sector", "scenario", "year", "name_ald")
+  by_company <- c("sector", "scenario", "year", "region", "name_ald")
   crucial <- c(by_company, "technology", "weighted_production", "tmsr", "smsp")
 
   check_crucial_names(data, crucial)
@@ -48,7 +48,7 @@ target_market_share_company <- function(data) {
       sector_weighted_production = sum(.data$weighted_production)
     ) %>%
     dplyr::arrange(.data$year) %>%
-    dplyr::group_by(.data$sector, .data$scenario, .data$name_ald) %>%
+    dplyr::group_by(.data$sector, .data$scenario, .data$region, .data$name_ald) %>%
     dplyr::filter(dplyr::row_number() == 1L) %>%
     dplyr::rename(
       initial_sector_production = .data$sector_weighted_production
@@ -65,6 +65,7 @@ target_market_share_company <- function(data) {
       .data$sector,
       .data$technology,
       .data$scenario,
+      .data$region,
       .data$name_ald
     ) %>%
     dplyr::filter(dplyr::row_number() == 1L) %>%
@@ -76,11 +77,11 @@ target_market_share_company <- function(data) {
   data %>%
     dplyr::left_join(
       initial_sector_summaries,
-      by = c("sector", "scenario", "name_ald")
+      by = c("sector", "scenario", "region", "name_ald")
     ) %>%
     dplyr::left_join(
       initial_technology_summaries,
-      by = c("sector", "scenario", "technology", "name_ald")
+      by = c("sector", "scenario", "technology", "region", "name_ald")
     ) %>%
     dplyr::mutate(
       tmsr_target_weighted_production = .data$initial_technology_production *

--- a/R/target_market_share_portfolio.R
+++ b/R/target_market_share_portfolio.R
@@ -33,7 +33,7 @@
 target_market_share_portfolio <- function(data) {
   stopifnot(is.data.frame(data))
 
-  by_portfolio <- c("sector", "scenario", "year")
+  by_portfolio <- c("sector", "scenario", "year", "region")
   crucial <-
     c(by_portfolio, "technology", "weighted_production", "tmsr", "smsp")
 
@@ -49,7 +49,7 @@ target_market_share_portfolio <- function(data) {
       sector_weighted_production = sum(.data$weighted_production)
     ) %>%
     dplyr::arrange(.data$year) %>%
-    dplyr::group_by(.data$sector, .data$scenario) %>%
+    dplyr::group_by(.data$sector, .data$scenario, .data$region) %>%
     dplyr::filter(dplyr::row_number() == 1L) %>%
     dplyr::rename(
       initial_sector_production = .data$sector_weighted_production
@@ -62,18 +62,18 @@ target_market_share_portfolio <- function(data) {
       technology_weighted_production = sum(.data$weighted_production)
     ) %>%
     dplyr::arrange(.data$year) %>%
-    dplyr::group_by(.data$sector, .data$technology, .data$scenario) %>%
+    dplyr::group_by(.data$sector, .data$technology, .data$scenario, .data$region) %>%
     dplyr::filter(dplyr::row_number() == 1L) %>%
     dplyr::rename(
       initial_technology_production = .data$technology_weighted_production
     ) %>%
     select(-.data$year)
 
-  data %>%
-    dplyr::left_join(initial_sector_summaries, by = c("sector", "scenario")) %>%
+  tmp <- data %>%
+    dplyr::left_join(initial_sector_summaries, by = c("sector", "scenario", "region")) %>%
     dplyr::left_join(
       initial_technology_summaries,
-      by = c("sector", "scenario", "technology")
+      by = c("sector", "scenario", "region", "technology")
     ) %>%
     dplyr::mutate(
       tmsr_target_weighted_production = .data$initial_technology_production *

--- a/tests/testthat/test-target_market_share_company.R
+++ b/tests/testthat/test-target_market_share_company.R
@@ -110,3 +110,26 @@ test_that("with known input outputs as expected", {
   )
 
 })
+
+test_that("portfolio values and targets have identical values at start year (#87)", {
+  data <- fake_master(
+    name_ald = "comp",
+    technology = c("electric", "ice", "electric", "ice"),
+    year = c(2020, 2020, 2020, 2020),
+    region = c("global", "global", "europe", "europe"),
+    scenario = "sds",
+    tmsr = 1,
+    smsp = 0,
+    weighted_production = c(200, 250, 100, 150)
+  )
+  out <- target_market_share_portfolio(data)
+
+  out %>%
+    dplyr::filter(year == min(year)) %>%
+    dplyr::group_by(sector, technology, region, name_ald) %>%
+    dplyr::summarise(distinct_intial_values = dplyr::n_distinct(weighted_production_value)) %>%
+    dplyr::mutate(initial_values_are_equal = (.data$distinct_intial_values == 1))
+
+  expect_true(out$initial_values_are_equal)
+
+})

--- a/tests/testthat/test-target_market_share_company.R
+++ b/tests/testthat/test-target_market_share_company.R
@@ -12,7 +12,7 @@ test_that("with fake data outputs known value", {
   out <- summarize_company_production(fake_master()) %>%
     target_market_share_company()
 
-  expect_known_value(out, "ref-target_market_share_company", update = TRUE)
+  expect_known_value(out, "ref-target_market_share_company", update = FALSE)
 })
 
 test_that("with data lacking crucial columns errors with informative message", {
@@ -122,14 +122,12 @@ test_that("portfolio values and targets have identical values at start year (#87
     smsp = 0,
     weighted_production = c(200, 250, 100, 150)
   )
-  out <- target_market_share_portfolio(data)
-
-  out %>%
+  out <- target_market_share_company(data) %>%
     dplyr::filter(year == min(year)) %>%
     dplyr::group_by(sector, technology, region, name_ald) %>%
     dplyr::summarise(distinct_intial_values = dplyr::n_distinct(weighted_production_value)) %>%
     dplyr::mutate(initial_values_are_equal = (.data$distinct_intial_values == 1))
 
-  expect_true(out$initial_values_are_equal)
+  expect_true(all(out$initial_values_are_equal))
 
 })

--- a/tests/testthat/test-target_market_share_portfolio.R
+++ b/tests/testthat/test-target_market_share_portfolio.R
@@ -81,7 +81,7 @@ test_that("outputs expected names", {
 
 test_that("with grouped data returns same groups as input", {
   out <- fake_master() %>%
-    summarize_company_production() %>%
+    summarize_portfolio_production() %>%
     dplyr::group_by(.data$sector) %>%
     target_market_share_portfolio()
 
@@ -104,4 +104,26 @@ test_that("with known input outputs as expected", {
     dplyr::filter(weighted_production_metric == "target_sds")
 
   expect_equal(out_target$weighted_production_value, c(200, 250, 353, 150))
+})
+
+test_that("portfolio values and targets have identical values at start year (#87)", {
+  data <- fake_master(
+    technology = c("electric", "ice", "electric", "ice"),
+    year = c(2020, 2020, 2020, 2020),
+    region = c("global", "global", "europe", "europe"),
+    scenario = "sds",
+    tmsr = 1,
+    smsp = 0,
+    weighted_production = c(200, 250, 100, 150)
+  )
+  out <- target_market_share_portfolio(data)
+
+  out %>%
+    dplyr::filter(year == min(year)) %>%
+    dplyr::group_by(sector, technology, region) %>%
+    dplyr::summarise(distinct_intial_values = dplyr::n_distinct(weighted_production_value)) %>%
+    dplyr::mutate(initial_values_are_equal = (.data$distinct_intial_values == 1))
+
+  expect_true(out$initial_values_are_equal)
+
 })

--- a/tests/testthat/test-target_market_share_portfolio.R
+++ b/tests/testthat/test-target_market_share_portfolio.R
@@ -116,14 +116,12 @@ test_that("portfolio values and targets have identical values at start year (#87
     smsp = 0,
     weighted_production = c(200, 250, 100, 150)
   )
-  out <- target_market_share_portfolio(data)
-
-  out %>%
+  out <- target_market_share_portfolio(data) %>%
     dplyr::filter(year == min(year)) %>%
     dplyr::group_by(sector, technology, region) %>%
     dplyr::summarise(distinct_intial_values = dplyr::n_distinct(weighted_production_value)) %>%
     dplyr::mutate(initial_values_are_equal = (.data$distinct_intial_values == 1))
 
-  expect_true(out$initial_values_are_equal)
+  expect_true(all(out$initial_values_are_equal))
 
 })


### PR DESCRIPTION
* Added a test to identify bug where portfolio and targets did not originate from same value at start year
* Fixed bug

See reprex below: 
``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(ggplot2)
library(r2dii.data)
library(r2dii.match)
library(r2dii.analysis)

matched <- match_name(loanbook_demo, ald_demo) %>%
  prioritize()

loanbook_joined_to_ald_scenario <- matched %>% 
  join_ald_scenario(
    ald = ald_demo, 
    scenario = scenario_demo_2020, 
    region_isos = region_isos_demo
  )

market_share_targets_portfolio <- loanbook_joined_to_ald_scenario %>% 
  summarize_portfolio_production() %>% 
  target_market_share_portfolio()

market_share_targets_portfolio %>% 
  dplyr::filter(region == "global") %>% 
  group_by(weighted_production_metric) %>% 
  ggplot(aes(x = year, y = weighted_production_value, color = weighted_production_metric)) + 
  geom_line() + 
  facet_wrap(sector ~ technology, scales = "free_y")+
  ggtitle("Global")
```

![](https://i.imgur.com/bRPK8gz.png)

<sup>Created on 2020-06-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Closes #87 