### PR TITLE
`target_sda()` with missing crucial values errors with informative message

### DIFF
--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -32,40 +32,42 @@
 #' @family functions to calculate scenario targets
 #'
 #' @examples
-#' installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
-#'   requireNamespace("r2dii.match", quietly = TRUE)
+#' installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
+#'   requireNamespace("r2dii.data", quietly = TRUE)
 #' if (!installed) stop("Please install r2dii.match and r2dii.data")
 #'
-#' library(r2dii.data)
 #' library(r2dii.match)
+#' library(r2dii.data)
 #'
-#' valid_matches <- match_name(loanbook_demo, ald_demo) %>%
-#'   # WARNING: Remember to validate matches (see `?prioritize`)
-#'   prioritize()
+#' # Example datasets from r2dii.data
+#' loanbook <- loanbook_demo
+#' ald <- ald_demo
+#' co2_scenario <- co2_intensity_scenario_demo
 #'
-#' ald <- na.omit(ald_demo)
+#' # WARNING: Remember to validate matches (see `?prioritize`)
+#' matched <- prioritize(match_name(loanbook, ald))
 #'
-#' out <- valid_matches %>%
-#'   target_sda(
-#'     ald = ald,
-#'     co2_intensity_scenario = co2_intensity_scenario_demo
-#'   )
+#' # You may need to clean your data
+#' anyNA(ald$emission_factor)
+#' try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
+#'
+#' ald2 <- subset(ald, !is.na(emission_factor))
+#' anyNA(ald2$emission_factor)
+#'
+#' out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
 #'
 #' # The output includes the portfolio's actual projected emissions factors, the
 #' # scenario pathway emissions factors, and the portfolio's target emissions
 #' # factors.
 #' out
 #'
-#' # Split view by metric
+#' # Split-view by metric
 #' split(out, out$emission_factor_metric)
 #'
-#' # calculate company-level targets
-#' out <- valid_matches %>%
-#'   target_sda(
-#'     ald = ald,
-#'     co2_intensity_scenario = co2_intensity_scenario_demo,
-#'     by_company = TRUE
-#'   )
+#' # Calculate company-level targets
+#' out <- target_sda(
+#'   matched, ald2, co2_intensity_scenario = co2_scenario, by_company = TRUE
+#' )
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -66,7 +66,8 @@
 #'
 #' # Calculate company-level targets
 #' out <- target_sda(
-#'   matched, ald2, co2_intensity_scenario = co2_scenario, by_company = TRUE
+#'   matched, ald2,
+#'   co2_intensity_scenario = co2_scenario, by_company = TRUE
 #' )
 target_sda <- function(data,
                        ald,

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -101,8 +101,14 @@ target_sda <- function(data,
   )
 
   check_crucial_names(data, crucial_portfolio)
+  walk(crucial_portfolio, ~ check_no_value_is_missing(data, .x))
+
   check_crucial_names(ald, crucial_ald)
+  walk(crucial_ald, ~ check_no_value_is_missing(ald, .x))
+
   check_crucial_names(co2_intensity_scenario, crucial_scenario)
+  walk(crucial_scenario, ~ check_no_value_is_missing(co2_intensity_scenario, .x))
+
 
   loanbook_summary_groups <- maybe_add_name_ald(
     c("sector_ald", "year"),

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -43,7 +43,7 @@
 #'   # WARNING: Remember to validate matches (see `?prioritize`)
 #'   prioritize()
 #'
-#' ald <- filter(ald_demo, !is.na(emission_factor))
+#' ald <- na.omit(ald_demo)
 #'
 #' out <- valid_matches %>%
 #'   target_sda(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -43,9 +43,11 @@
 #'   # WARNING: Remember to validate matches (see `?prioritize`)
 #'   prioritize()
 #'
+#' ald <- filter(ald_demo, !is.na(emission_factor))
+#'
 #' out <- valid_matches %>%
 #'   target_sda(
-#'     ald = ald_demo,
+#'     ald = ald,
 #'     co2_intensity_scenario = co2_intensity_scenario_demo
 #'   )
 #'
@@ -60,7 +62,7 @@
 #' # calculate company-level targets
 #' out <- valid_matches %>%
 #'   target_sda(
-#'     ald = ald_demo,
+#'     ald = ald,
 #'     co2_intensity_scenario = co2_intensity_scenario_demo,
 #'     by_company = TRUE
 #'   )

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -60,7 +60,7 @@ valid_matches <- match_name(loanbook_demo, ald_demo) \%>\%
   # WARNING: Remember to validate matches (see `?prioritize`)
   prioritize()
 
-ald <- filter(ald_demo, !is.na(emission_factor))
+ald <- na.omit(ald_demo)
 
 out <- valid_matches \%>\%
   target_sda(

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -83,7 +83,8 @@ split(out, out$emission_factor_metric)
 
 # Calculate company-level targets
 out <- target_sda(
-  matched, ald2, co2_intensity_scenario = co2_scenario, by_company = TRUE
+  matched, ald2,
+  co2_intensity_scenario = co2_scenario, by_company = TRUE
 )
 }
 \seealso{

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -49,40 +49,42 @@ This function ignores existing groups and outputs ungrouped data.
 }
 
 \examples{
-installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
-  requireNamespace("r2dii.match", quietly = TRUE)
+installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
+  requireNamespace("r2dii.data", quietly = TRUE)
 if (!installed) stop("Please install r2dii.match and r2dii.data")
 
-library(r2dii.data)
 library(r2dii.match)
+library(r2dii.data)
 
-valid_matches <- match_name(loanbook_demo, ald_demo) \%>\%
-  # WARNING: Remember to validate matches (see `?prioritize`)
-  prioritize()
+# Example datasets from r2dii.data
+loanbook <- loanbook_demo
+ald <- ald_demo
+co2_scenario <- co2_intensity_scenario_demo
 
-ald <- na.omit(ald_demo)
+# WARNING: Remember to validate matches (see `?prioritize`)
+matched <- prioritize(match_name(loanbook, ald))
 
-out <- valid_matches \%>\%
-  target_sda(
-    ald = ald,
-    co2_intensity_scenario = co2_intensity_scenario_demo
-  )
+# You may need to clean your data
+anyNA(ald$emission_factor)
+try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
+
+ald2 <- subset(ald, !is.na(emission_factor))
+anyNA(ald2$emission_factor)
+
+out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
 
 # The output includes the portfolio's actual projected emissions factors, the
 # scenario pathway emissions factors, and the portfolio's target emissions
 # factors.
 out
 
-# Split view by metric
+# Split-view by metric
 split(out, out$emission_factor_metric)
 
-# calculate company-level targets
-out <- valid_matches \%>\%
-  target_sda(
-    ald = ald,
-    co2_intensity_scenario = co2_intensity_scenario_demo,
-    by_company = TRUE
-  )
+# Calculate company-level targets
+out <- target_sda(
+  matched, ald2, co2_intensity_scenario = co2_scenario, by_company = TRUE
+)
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -60,9 +60,11 @@ valid_matches <- match_name(loanbook_demo, ald_demo) \%>\%
   # WARNING: Remember to validate matches (see `?prioritize`)
   prioritize()
 
+ald <- filter(ald_demo, !is.na(emission_factor))
+
 out <- valid_matches \%>\%
   target_sda(
-    ald = ald_demo,
+    ald = ald,
     co2_intensity_scenario = co2_intensity_scenario_demo
   )
 
@@ -77,7 +79,7 @@ split(out, out$emission_factor_metric)
 # calculate company-level targets
 out <- valid_matches \%>\%
   target_sda(
-    ald = ald_demo,
+    ald = ald,
     co2_intensity_scenario = co2_intensity_scenario_demo,
     by_company = TRUE
   )

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -260,3 +260,93 @@ test_that("with no matching data warns", {
     target_sda(fake_matched(), fake_ald(), bad_scenario), "no scenario"
   )
 })
+
+test_that("with NAs in crucial columns errors with informative message (#146)", {
+
+  expect_error_crucial_NAs_portfolio <- function(name) {
+    data <- fake_matched(sector_ald = "cement")
+
+    ald <- fake_ald(
+      sector = "cement",
+      year = c(2020, 2050)
+    )
+
+    scen <- fake_co2_scenario(
+      emission_factor = c(1, 2),
+      year = c(2020, 2050)
+    )
+
+    data[1, name] <- NA
+    expect_error(
+      class = "some_value_is_missing",
+      target_sda(
+        data,
+        ald,
+        scen
+      )
+    )
+  }
+
+  expect_error_crucial_NAs_ald <- function(name) {
+    match_result <- fake_matched(sector_ald = "cement")
+
+    data <- fake_ald(
+      sector = "cement",
+      year = c(2020, 2050)
+    )
+
+    scen <- fake_co2_scenario(
+      emission_factor = c(1, 2),
+      year = c(2020, 2050)
+    )
+
+
+    data[1, name] <- NA
+    expect_error(
+      class = "some_value_is_missing",
+      target_sda(
+        match_result,
+        data,
+        scen
+      )
+    )
+  }
+
+  expect_error_crucial_NAs_scenario <- function(name) {
+    match_result <- fake_matched(sector_ald = "cement")
+
+    ald <- fake_ald(
+      sector = "cement",
+      year = c(2020, 2050)
+    )
+
+    data <- fake_co2_scenario(
+      emission_factor = c(1, 2),
+      year = c(2020, 2050)
+    )
+
+    data[1, name] <- NA
+
+    expect_error(
+      class = "some_value_is_missing",
+      target_sda(
+        match_result,
+        ald,
+        data
+      )
+    )
+  }
+
+  expect_error_crucial_NAs_portfolio("name_ald")
+  expect_error_crucial_NAs_portfolio("sector_ald")
+
+  expect_error_crucial_NAs_ald("name_company")
+  expect_error_crucial_NAs_ald("production")
+  expect_error_crucial_NAs_ald("emission_factor")
+  expect_error_crucial_NAs_ald("sector")
+  expect_error_crucial_NAs_ald("year")
+
+  expect_error_crucial_NAs_scenario("sector")
+  expect_error_crucial_NAs_scenario("year")
+  expect_error_crucial_NAs_scenario("emission_factor")
+})

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -262,7 +262,6 @@ test_that("with no matching data warns", {
 })
 
 test_that("with NAs in crucial columns errors with informative message (#146)", {
-
   expect_error_crucial_NAs_portfolio <- function(name) {
     data <- fake_matched(sector_ald = "cement")
 


### PR DESCRIPTION
I noticed that the example target_sda output had `NA`s. 
This was a result of input data have `NA`s in the `emission_factor` columns for some sectors. 

`target_sda` now aborts if any crucial columns contain `NA`s. 

Closes #156 