### PR TITLE
Check that `id_loan` is not duplicated

### DIFF
--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -109,10 +109,11 @@ target_sda <- function(data,
     by_company
   )
 
-  loanbook_with_weighted_emission_factors <- data %>%
-    calculate_weighted_emission_factor(ald,
-      !!!rlang::syms(loanbook_summary_groups),
-      use_credit_limit = use_credit_limit
+  loanbook_with_weighted_emission_factors <-  calculate_weighted_emission_factor(
+    data,
+    ald,
+    !!!rlang::syms(loanbook_summary_groups),
+    use_credit_limit = use_credit_limit
     )
 
   if (identical(nrow(loanbook_with_weighted_emission_factors), 0L)) {

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -203,7 +203,7 @@ calculate_weighted_emission_factor <- function(data,
 add_loan_weighted_emission_factor <- function(data, use_credit_limit, by_company = FALSE) {
   if (by_company) {
     data %>%
-      mutate(weighted_loan_emission_factor = emission_factor)
+      mutate(weighted_loan_emission_factor = .data$emission_factor)
   } else{
     loan_size <- paste0(
       "loan_size_", ifelse(use_credit_limit, "credit_limit", "outstanding")

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -121,13 +121,13 @@ target_sda <- function(data,
     by_company
   )
 
-  loanbook_with_weighted_emission_factors <-  calculate_weighted_emission_factor(
+  loanbook_with_weighted_emission_factors <- calculate_weighted_emission_factor(
     data,
     ald,
     !!!rlang::syms(loanbook_summary_groups),
     use_credit_limit = use_credit_limit,
     by_company = by_company
-    )
+  )
 
   if (identical(nrow(loanbook_with_weighted_emission_factors), 0L)) {
     rlang::warn("Found no match between loanbook and ald.")
@@ -190,8 +190,10 @@ calculate_weighted_emission_factor <- function(data,
                                                by_company = FALSE) {
   data %>%
     inner_join(ald, by = ald_columns()) %>%
-    add_loan_weighted_emission_factor(use_credit_limit = use_credit_limit,
-                                      by_company = by_company) %>%
+    add_loan_weighted_emission_factor(
+      use_credit_limit = use_credit_limit,
+      by_company = by_company
+    ) %>%
     group_by(...) %>%
     summarize(
       emission_factor_projected = sum(.data$weighted_loan_emission_factor)
@@ -204,7 +206,7 @@ add_loan_weighted_emission_factor <- function(data, use_credit_limit, by_company
   if (by_company) {
     data %>%
       mutate(weighted_loan_emission_factor = .data$emission_factor)
-  } else{
+  } else {
     loan_size <- paste0(
       "loan_size_", ifelse(use_credit_limit, "credit_limit", "outstanding")
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,8 @@ check_unique_id <- function(data, column){
       sprintf("Column `%s` must not contain any duplicates.", column)
     )
   }
+
+  invisible(data)
 }
 
 warn_grouped <- function(data, message) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,7 +9,7 @@ check_no_value_is_missing <- function(data, column) {
   invisible(data)
 }
 
-check_unique_id <- function(data, column){
+check_unique_id <- function(data, column) {
   if (sum(duplicated(data[[column]]))) {
     abort(
       class = "unique_ids",

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,6 +9,15 @@ check_no_value_is_missing <- function(data, column) {
   invisible(data)
 }
 
+check_unique_id <- function(data, column){
+  if (sum(duplicated(data[[column]]))) {
+    abort(
+      class = "unique_ids",
+      sprintf("Column `%s` must not contain any duplicates.", column)
+    )
+  }
+}
+
 warn_grouped <- function(data, message) {
   if (dplyr::is_grouped_df(data)) warn(message)
 

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -260,3 +260,32 @@ test_that("with no matching data warns", {
     target_sda(fake_matched(), fake_ald(), bad_scenario), "no scenario"
   )
 })
+
+test_that("with duplicated id_loan weights emission_factor as expected (#160)", {
+  match_result <- fake_matched(
+    id_loan = c(1,1),
+    name_ald = rep("large company", 2),
+    sector_ald = "cement"
+  )
+
+  ald <- fake_ald(
+    sector = "cement",
+    name_company = "large company",
+    emission_factor = 2,
+    year = c(2020, 2025)
+  )
+
+  scen <- fake_co2_scenario(
+    year = c(2020, 2025),
+    emission_factor = c(1, 0.5)
+  )
+
+  out <- target_sda(match_result,
+             ald,
+             scen) %>%
+    filter(year == min(year))
+
+  split_out <- split(out, out$emission_factor_metric)
+
+  expect_equal(split_out$projected$emission_factor_value, 2)
+})

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -208,6 +208,7 @@ test_that("with known input outputs as expected", {
 
 test_that("with known input outputs as expected, at company level (#155)", {
   matched <- fake_matched(
+    id_loan = c(1,2),
     name_ald = c("shaanxi auto", "company 2"),
     sector_ald = "cement"
   )
@@ -280,12 +281,11 @@ test_that("with duplicated id_loan weights emission_factor as expected (#160)", 
     emission_factor = c(1, 0.5)
   )
 
-  out <- target_sda(match_result,
+  expect_error(
+    target_sda(match_result,
              ald,
              scen) %>%
-    filter(year == min(year))
-
-  split_out <- split(out, out$emission_factor_metric)
-
-  expect_equal(split_out$projected$emission_factor_value, 2)
+    filter(year == min(year)),
+    class =  "unique_ids"
+  )
 })

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -208,7 +208,7 @@ test_that("with known input outputs as expected", {
 
 test_that("with known input outputs as expected, at company level (#155)", {
   matched <- fake_matched(
-    id_loan = c(1,2),
+    id_loan = c(1, 2),
     name_ald = c("shaanxi auto", "company 2"),
     sector_ald = "cement"
   )
@@ -264,7 +264,7 @@ test_that("with no matching data warns", {
 
 test_that("with duplicated id_loan weights emission_factor as expected (#160)", {
   match_result <- fake_matched(
-    id_loan = c(1,1),
+    id_loan = c(1, 1),
     name_ald = rep("large company", 2),
     sector_ald = "cement"
   )
@@ -282,11 +282,13 @@ test_that("with duplicated id_loan weights emission_factor as expected (#160)", 
   )
 
   expect_error(
-    target_sda(match_result,
-             ald,
-             scen) %>%
-    filter(year == min(year)),
-    class =  "unique_ids"
+    target_sda(
+      match_result,
+      ald,
+      scen
+    ) %>%
+      filter(year == min(year)),
+    class = "unique_ids"
   )
 })
 


### PR DESCRIPTION
This relates to a bug identified by multiple users, where `projected` `emission_factors` were unreasonably large. 

This was a result of the input data having duplicate `id_loans` per loan. The result was that, while the loan weights was calculated per `id_loan`, the `emission_factor` was summed across each loan weight, causing double-counting (sometimes more). 

I decided to go the more harsh route, and cause the function to `error` if input `id_loans` were duplicated. This will save us headache down the road, as these `id`s should uniquely identify EVERY loan (otherwise we're gonna have problems). 

I also noticed that the `emission_factor` was still being weighted when `by_company = TRUE` which doesn't make sense, so fixed that as well. 

Maybe closes #160 