### PR TITLE
Fix unweighted company

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs unweighted production when 
+  multiple loans exist for the same company (#239).
+
 * `target_sda()` now interpolates input scenario file by year and correctly 
   calculates target, regardless of the time-horizon of `ald` (#234).
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -63,6 +63,8 @@ summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
 
 summarize_unweighted_production <- function(data, ...) {
   data %>%
+    select(-.data$id_loan) %>%
+    distinct() %>%
     group_by(...) %>%
     summarize(weighted_production = sum(.data$production), .groups = "keep") %>%
     ungroup(.data$technology) %>%

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -222,7 +222,7 @@ test_that("with known input outputs as expected, at company level", {
 
   expect_equal(
     out_target$production,
-    c(20, 180, 47.2, 305.8, 60, 190, 36, 114)
+    c(10, 90, 23.6, 152.9, 30, 95, 18, 57)
   )
 })
 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -521,3 +521,26 @@ test_that("w/ technology in ald but not loanbook, outputs all techs (#235)", {
   expect_equal(corporate_economy$ice$technology_share, 0.25)
   expect_equal(corporate_economy$electric$technology_share, 0.75)
 })
+
+test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)", {
+
+  matched <- fake_matched(id_loan = c("L1", "L2"))
+
+  ald <- fake_ald()
+
+  scenario <- fake_scenario()
+
+  out <- target_market_share(
+    matched,
+    ald,
+    scenario,
+    region_isos_stable,
+    by_company = TRUE,
+    weight_production = FALSE
+  )
+
+  projected <- filter(out, metric == "projected")
+
+  expect_equal(projected$production, ald$production)
+
+})

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -523,10 +523,9 @@ test_that("w/ technology in ald but not loanbook, outputs all techs (#235)", {
 })
 
 test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)", {
+
   matched <- fake_matched(id_loan = c("L1", "L2"))
-
   ald <- fake_ald()
-
   scenario <- fake_scenario()
 
   out <- target_market_share(

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -523,7 +523,6 @@ test_that("w/ technology in ald but not loanbook, outputs all techs (#235)", {
 })
 
 test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)", {
-
   matched <- fake_matched(id_loan = c("L1", "L2"))
 
   ald <- fake_ald()
@@ -542,5 +541,4 @@ test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)",
   projected <- filter(out, metric == "projected")
 
   expect_equal(projected$production, ald$production)
-
 })


### PR DESCRIPTION
`summarize_unweighted_production` now drops the crucial column `id_loan` and selects distinct values, to avoid erroneous double-counting when calculating the `unweighted` company production. 

Closes #239