### PR TITLE
Reweight `technology_share` prior to output. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now outputs `weighted_technology_share` that 
+  correctly sums to 1 when grouped by `sector`, `metric` and `secnario` (#218).
+
 * `target_market_share()` now correctly outputs unweighted production when 
   multiple loans exist for the same company (#239).
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -380,7 +380,7 @@ reweight_technology_share <- function(data, ...){
   data %>%
     group_by(...) %>%
     mutate(
-      .x = weighted_technology_share,
+      .x = .data$weighted_technology_share,
       weighted_technology_share = .data$.x/sum(.data$.x),
       .x = NULL
     ) %>%

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -376,15 +376,13 @@ empty_target_market_share_output <- function() {
   )
 }
 
-reweight_technology_share <- function(data, ...){
+reweight_technology_share <- function(data, ...) {
   data %>%
     group_by(...) %>%
     mutate(
       .x = .data$weighted_technology_share,
-      weighted_technology_share = .data$.x/sum(.data$.x),
+      weighted_technology_share = .data$.x / sum(.data$.x),
       .x = NULL
     ) %>%
     ungroup()
-
-
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -107,25 +107,23 @@ target_market_share <- function(data,
     by_company
   )
 
-  data <- data %>%
-    join_ald_scenario(ald, scenario, region_isos) %>%
-    {
-      if (weight_production) {
-        summarize_weighted_production(
-          .,
-          !!!rlang::syms(summary_groups),
-          use_credit_limit = use_credit_limit
-        )
-      } else {
-        summarize_unweighted_production(
-          .,
-          .data$sector_ald,
-          .data$technology,
-          .data$year,
-          !!!rlang::syms(summary_groups)
-        )
-      }
-    }
+  data <- join_ald_scenario(data, ald, scenario, region_isos)
+
+  if (weight_production) {
+    data <- summarize_weighted_production(
+      data,
+      !!!rlang::syms(summary_groups),
+      use_credit_limit = use_credit_limit
+    )
+  } else {
+    data <- summarize_unweighted_production(
+      data,
+      .data$sector_ald,
+      .data$technology,
+      .data$year,
+      !!!rlang::syms(summary_groups)
+    )
+  }
 
   if (nrow(data) == 0) {
     return(empty_target_market_share_output())

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -125,6 +125,16 @@ target_market_share <- function(data,
     )
   }
 
+  reweighting_groups <- maybe_add_name_ald(
+    c("sector_ald", "region", "scenario", "scenario_source", "year"),
+    by_company
+  )
+
+  data <- reweight_technology_share(
+    data,
+    !!!rlang::syms(reweighting_groups)
+  )
+
   if (nrow(data) == 0) {
     return(empty_target_market_share_output())
   }
@@ -364,4 +374,17 @@ empty_target_market_share_output <- function() {
     production = numeric(0),
     technology_share = numeric(0)
   )
+}
+
+reweight_technology_share <- function(data, ...){
+  data %>%
+    group_by(...) %>%
+    mutate(
+      .x = weighted_technology_share,
+      weighted_technology_share = .data$.x/sum(.data$.x),
+      .x = NULL
+    ) %>%
+    ungroup()
+
+
 }

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -521,3 +521,25 @@ test_that("w/ technology in ald but not loanbook, outputs all techs (#235)", {
   expect_equal(corporate_economy$ice$technology_share, 0.25)
   expect_equal(corporate_economy$electric$technology_share, 0.75)
 })
+
+test_that("w/ multiple loans to same company, `technology_share` sums to one (#218)", {
+
+  shares_sum_to_one <- function(data) {
+
+    technology_share_sum <- data %>%
+      group_by(sector, metric) %>%
+      summarize(share_sum = sum(technology_share), .groups = "drop")
+
+    all(technology_share_sum$share_sum == 1)
+  }
+
+  # multiple loans to same company
+  out <- target_market_share(
+    fake_matched(id_loan = c("L1", "L2")),
+    fake_ald(),
+    fake_scenario(),
+    region_isos_stable
+  )
+
+  expect_true(shares_sum_to_one(out))
+})

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -523,7 +523,6 @@ test_that("w/ technology in ald but not loanbook, outputs all techs (#235)", {
 })
 
 test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)", {
-
   matched <- fake_matched(id_loan = c("L1", "L2"))
   ald <- fake_ald()
   scenario <- fake_scenario()
@@ -543,9 +542,7 @@ test_that("w/ unweighted company flags & multi loans, outputs correctly (#239)",
 })
 
 test_that("w/ multiple loans to same company, `technology_share` sums to one (#218)", {
-
   shares_sum_to_one <- function(data) {
-
     technology_share_sum <- data %>%
       group_by(sector, metric) %>%
       summarize(share_sum = sum(technology_share), .groups = "drop")
@@ -563,4 +560,3 @@ test_that("w/ multiple loans to same company, `technology_share` sums to one (#2
 
   expect_true(shares_sum_to_one(out))
 })
-


### PR DESCRIPTION
Closes #218

This is not the most elegant solution, as I am simply re-weighting the `technology_share`, after it is calculated and summarized, which sorta feels like cheating, but I can't think of something more clever. 

The issue is that, for example, if we have company level results, we may have a table like: 
``` r
tibble::tribble(
  ~name_company, ~technology, ~technology_share,
            "a",  "electric",               0.5,
            "a",       "ice",               0.5,
            "b",  "electric",              0.25,
            "b",       "ice",              0.75
  )
#> # A tibble: 4 x 3
#>   name_company technology technology_share
#>   <chr>        <chr>                 <dbl>
#> 1 a            electric               0.5 
#> 2 a            ice                    0.5 
#> 3 b            electric               0.25
#> 4 b            ice                    0.75
```

<sup>Created on 2020-12-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

and if we then want to aggregate to portfolio level, a simple sum would result in: 
``` r
tibble::tribble(
  ~technology, ~technology_share,
   "electric",             0.375,
        "ice",             0.625
  )
#> # A tibble: 2 x 2
#>   technology technology_share
#>   <chr>                 <dbl>
#> 1 electric              0.375
#> 2 ice                   0.625
```

<sup>Created on 2020-12-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

which is basically a weighted sum of those. This can be achieved by simply aggregating the usual share, and then just re-normalizing (which is what I've done here). 

My brain is kinda mush right now, so if you can think of a more clever way to do this than what is in this PR, then by all means, but this satisfies the test condition for now. 

Closes #218