### PR TITLE
Unweighted market share target outputs correctly with multiple input `level`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs unweighted production when 
+  multiple levels exist for the same company (#249).
+
 # r2dii.analysis 0.1.2
 
 * `target_market_share()` now outputs `weighted_technology_share` that 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -63,7 +63,7 @@ summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
 
 summarize_unweighted_production <- function(data, ...) {
   data %>%
-    select(-.data$id_loan) %>%
+    select(-c(.data$id_loan, .data$level)) %>%
     distinct() %>%
     group_by(...) %>%
     summarize(weighted_production = sum(.data$production), .groups = "keep") %>%

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -562,7 +562,6 @@ test_that("w/ multiple loans to same company, `technology_share` sums to one (#2
 })
 
 test_that("w/ multiple match `level`, unweighted production is equal to ALD production (#249)", {
-
   matched <- fake_matched(
     id_loan = c(1, 2),
     level = c("direct_loantaker", "ultimate_parent"),
@@ -580,9 +579,8 @@ test_that("w/ multiple match `level`, unweighted production is equal to ALD prod
   ald_production <- fake_ald() %>%
     pull(production)
 
-  out_production <- filter(out, metric ==  "projected") %>%
+  out_production <- filter(out, metric == "projected") %>%
     pull(production)
 
   expect_equal(ald_production, out_production)
-
 })

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -560,3 +560,29 @@ test_that("w/ multiple loans to same company, `technology_share` sums to one (#2
 
   expect_true(shares_sum_to_one(out))
 })
+
+test_that("w/ multiple match `level`, unweighted production is equal to ALD production (#249)", {
+
+  matched <- fake_matched(
+    id_loan = c(1, 2),
+    level = c("direct_loantaker", "ultimate_parent"),
+  )
+
+  out <- target_market_share(
+    matched,
+    fake_ald(),
+    fake_scenario(),
+    r2dii.data::region_isos_demo,
+    by_company = TRUE,
+    weight_production = FALSE
+  )
+
+  ald_production <- fake_ald() %>%
+    pull(production)
+
+  out_production <- filter(out, metric ==  "projected") %>%
+    pull(production)
+
+  expect_equal(ald_production, out_production)
+
+})


### PR DESCRIPTION
Closes #249 