### PR TITLE
Aggregate all loans to the same company in `target_market_share`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs `technology_share` with multiple 
+  loans to the same company (@georgeharris2deg #262)
+
 # r2dii.analysis 0.1.3
 
 * `target_market_share()` now correctly outputs unweighted production when 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -95,6 +95,8 @@ target_market_share <- function(data,
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 
+  data <- aggregate_by_loan_id(data)
+
   crucial_scenario <- c("scenario", "tmsr", "smsp")
   check_crucial_names(scenario, crucial_scenario)
   check_crucial_names(ald, "is_ultimate_owner")
@@ -383,6 +385,20 @@ reweight_technology_share <- function(data, ...) {
       .x = .data$weighted_technology_share,
       weighted_technology_share = .data$.x / sum(.data$.x),
       .x = NULL
+    ) %>%
+    ungroup()
+}
+
+aggregate_by_loan_id <- function(data) {
+
+  aggregate_columns <- c("id_loan", "loan_size_outstanding", "loan_size_credit_limit")
+
+  data %>%
+    dplyr::group_by_at(setdiff(names(data), aggregate_columns)) %>%
+    summarize(
+      id_loan = first(id_loan),
+      loan_size_outstanding = sum(loan_size_outstanding),
+      loan_size_credit_limit = sum(loan_size_credit_limit)
     ) %>%
     ungroup()
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -396,9 +396,9 @@ aggregate_by_loan_id <- function(data) {
   data %>%
     dplyr::group_by_at(setdiff(names(data), aggregate_columns)) %>%
     summarize(
-      id_loan = first(id_loan),
-      loan_size_outstanding = sum(loan_size_outstanding),
-      loan_size_credit_limit = sum(loan_size_credit_limit)
+      id_loan = first(.data$id_loan),
+      loan_size_outstanding = sum(.data$loan_size_outstanding),
+      loan_size_credit_limit = sum(.data$loan_size_credit_limit)
     ) %>%
     ungroup()
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -390,7 +390,6 @@ reweight_technology_share <- function(data, ...) {
 }
 
 aggregate_by_loan_id <- function(data) {
-
   aggregate_columns <- c("id_loan", "loan_size_outstanding", "loan_size_credit_limit")
 
   data %>%

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -403,7 +403,7 @@ test_that("outputs same names regardless of the value of `weight_production` (#1
   expect_equal(diff_names, character(0))
 })
 
-test_that("with known input outputs `technology_share` as expected (#184)", {
+test_that("with known input outputs `technology_share` as expected (#184, #262)", {
   matched <- fake_matched(
     id_loan = c("L1", "L2"),
     loan_size_outstanding = c(1, 3),
@@ -445,6 +445,77 @@ test_that("with known input outputs `technology_share` as expected (#184)", {
     c(0.923, 0.076),
     tolerance = 1e-3
   )
+
+  ################ More extensive test (#262)
+
+  matched <- fake_matched(
+    id_loan = c("L1", "L2", "L3"),
+    loan_size_outstanding = c(1000, 15000, 1200),
+    name_ald = c("a", "b", "a"),
+    id_2dii = c("DL1", "DL2", "DL1"),
+    sector = "power",
+    sector_ald = "power"
+  )
+
+  ald <- fake_ald(
+    name_company = rep(c("a", "b"), each = 6),
+    sector = "power",
+    technology = rep(
+      c(
+        "coalcap",
+        "gascap",
+        "hydrocap",
+        "nuclearcap",
+        "oilcap",
+        "renewablescap"
+        ),
+      2
+      ),
+    production = c(100, 200, 300, 100, 100, 200, 500, 0, 0, 300, 100, 100),
+    year = 2020
+  )
+
+  scenario <- fake_scenario(
+    sector = "power",
+    technology = c(
+      "coalcap",
+      "gascap",
+      "hydrocap",
+      "nuclearcap",
+      "oilcap",
+      "renewablescap"
+    ),
+    year = 2020,
+    tmsr = 1,
+    smsp = 0
+  )
+
+  out <- target_market_share(
+    matched,
+    ald,
+    scenario,
+    region_isos_stable
+  ) %>%
+    split(.$metric)
+
+  expect_equal(
+    out$projected$technology_share,
+    c(0.4488, 0.0255, 0.0383, 0.2744, 0.1, 0.1128),
+    tolerance = 1e-3
+  )
+
+  expect_equal(
+    out$target_sds$technology_share,
+    c(0.4488, 0.0255, 0.0383, 0.2744, 0.1, 0.1128),
+    tolerance = 1e-3
+  )
+
+  expect_equal(
+    out$corporate_economy$technology_share,
+    c(0.3, 0.1, 0.15, 0.2, 0.1, 0.15),
+    tolerance = 1e-3
+  )
+
 })
 
 test_that("w/ some region missing some scenario outputs expected `production`

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -468,9 +468,9 @@ test_that("with known input outputs `technology_share` as expected (#184, #262)"
         "nuclearcap",
         "oilcap",
         "renewablescap"
-        ),
-      2
       ),
+      2
+    ),
     production = c(100, 200, 300, 100, 100, 200, 500, 0, 0, 300, 100, 100),
     year = 2020
   )
@@ -515,7 +515,6 @@ test_that("with known input outputs `technology_share` as expected (#184, #262)"
     c(0.3, 0.1, 0.15, 0.2, 0.1, 0.15),
     tolerance = 1e-3
   )
-
 })
 
 test_that("w/ some region missing some scenario outputs expected `production`


### PR DESCRIPTION
As the first step of `target_market_share`, I now aggregate by `id_loan` to the same company on the input data. We likely could have done this much earlier, I don't recall now why I didn't... but all tests are passing and everything looks good so I think it should be ok!

Closes #262 