### PR TITLE
`target_market_share` errors if input `data` has unexpected columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r2dii.analysis
 Title: Tools to Calculate Climate Targets for Financial
     Portfolios
-Version: 0.1.4
+Version: 0.1.4.9000
 Authors@R: 
     c(person(given = "Jackson",
              family = "Hoffart",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs `technology_share` with
+  multiple loans to the same company (@georgeharris2deg #262).
+
 # r2dii.analysis 0.1.4
 
 * `target_market_share()` now correctly outputs unweighted production by

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now errors if input `data` has an unexpected column
+  (@georgeharris2deg #267).
+
 * `target_market_share()` now correctly outputs `technology_share` with
   multiple loans to the same company (@georgeharris2deg #262).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# r2dii.analysis (development version)
+
 # r2dii.analysis 0.1.4
 
 * `target_market_share()` now correctly outputs unweighted production by

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -94,7 +94,39 @@ target_market_share <- function(data,
   }
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
-  check_valid_columns(data)
+
+  valid_columns <- c(
+    "id_loan",
+    "id_direct_loantaker",
+    "name_direct_loantaker",
+    "id_intermediate_parent_1",
+    "name_intermediate_parent_1",
+    "id_ultimate_parent",
+    "name_ultimate_parent",
+    "loan_size_outstanding",
+    "loan_size_outstanding_currency",
+    "loan_size_credit_limit",
+    "loan_size_credit_limit_currency",
+    "sector_classification_system",
+    "sector_classification_input_type",
+    "sector_classification_direct_loantaker",
+    "fi_type",
+    "flag_project_finance_loan",
+    "name_project",
+    "lei_direct_loantaker",
+    "isin_direct_loantaker",
+    "id_2dii",
+    "level",
+    "sector",
+    "sector_ald",
+    "name",
+    "name_ald",
+    "score",
+    "source",
+    "borderline"
+  )
+
+  check_valid_columns(data, valid_columns)
   data <- aggregate_by_loan_id(data)
 
   crucial_scenario <- c("scenario", "tmsr", "smsp")
@@ -408,40 +440,9 @@ aggregate_by_loan_id <- function(data) {
     ungroup()
 }
 
-check_valid_columns <- function(data) {
+check_valid_columns <- function(data, valid_columns) {
 
-  possible_matched_columns <- c(
-    "id_loan",
-    "id_direct_loantaker",
-    "name_direct_loantaker",
-    "id_intermediate_parent_1",
-    "name_intermediate_parent_1",
-    "id_ultimate_parent",
-    "name_ultimate_parent",
-    "loan_size_outstanding",
-    "loan_size_outstanding_currency",
-    "loan_size_credit_limit",
-    "loan_size_credit_limit_currency",
-    "sector_classification_system",
-    "sector_classification_input_type",
-    "sector_classification_direct_loantaker",
-    "fi_type",
-    "flag_project_finance_loan",
-    "name_project",
-    "lei_direct_loantaker",
-    "isin_direct_loantaker",
-    "id_2dii",
-    "level",
-    "sector",
-    "sector_ald",
-    "name",
-    "name_ald",
-    "score",
-    "source",
-    "borderline"
-    )
-
-invalid_columns <- setdiff(names(data), possible_matched_columns)
+  invalid_columns <- setdiff(names(data), valid_columns)
 
   if (length(invalid_columns) != 0) {
     abort(

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -94,7 +94,7 @@ target_market_share <- function(data,
   }
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
-  check_unexpected_columns(data)
+  check_valid_columns(data)
   data <- aggregate_by_loan_id(data)
 
   crucial_scenario <- c("scenario", "tmsr", "smsp")
@@ -408,7 +408,7 @@ aggregate_by_loan_id <- function(data) {
     ungroup()
 }
 
-check_unexpected_columns <- function(data) {
+check_valid_columns <- function(data) {
 
   possible_matched_columns <- c(
     "id_loan",

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -441,12 +441,12 @@ check_valid_columns <- function(data) {
     "borderline"
     )
 
-unexpected_names <- setdiff(names(data), possible_matched_columns)
+invalid_columns <- setdiff(names(data), possible_matched_columns)
 
-  if (length(unexpected_names) != 0) {
+  if (length(invalid_columns) != 0) {
     abort(
-      glue("Loanbook has unexpected names: `{unexpected_names}`."),
-      class = "unexpected_names"
+      glue("Loanbook has unexpected names: `{invalid_columns}`."),
+      class = "invalid_columns"
     )
   }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -94,7 +94,7 @@ target_market_share <- function(data,
   }
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
-
+  check_unexpected_columns(data)
   data <- aggregate_by_loan_id(data)
 
   crucial_scenario <- c("scenario", "tmsr", "smsp")
@@ -390,7 +390,13 @@ reweight_technology_share <- function(data, ...) {
 }
 
 aggregate_by_loan_id <- function(data) {
-  aggregate_columns <- c("id_loan", "loan_size_outstanding", "loan_size_credit_limit")
+
+  aggregate_columns <- c(
+    "id_loan",
+    "loan_size_outstanding",
+    "loan_size_credit_limit"
+    )
+
 
   data %>%
     dplyr::group_by_at(setdiff(names(data), aggregate_columns)) %>%
@@ -400,4 +406,50 @@ aggregate_by_loan_id <- function(data) {
       loan_size_credit_limit = sum(.data$loan_size_credit_limit)
     ) %>%
     ungroup()
+}
+
+check_unexpected_columns <- function(data) {
+
+  possible_matched_columns <- c(
+    "id_loan",
+    "id_direct_loantaker",
+    "name_direct_loantaker",
+    "id_intermediate_parent_1",
+    "name_intermediate_parent_1",
+    "id_ultimate_parent",
+    "name_ultimate_parent",
+    "loan_size_outstanding",
+    "loan_size_outstanding_currency",
+    "loan_size_credit_limit",
+    "loan_size_credit_limit_currency",
+    "sector_classification_system",
+    "sector_classification_input_type",
+    "sector_classification_direct_loantaker",
+    "fi_type",
+    "flag_project_finance_loan",
+    "name_project",
+    "lei_direct_loantaker",
+    "isin_direct_loantaker",
+    "id_2dii",
+    "level",
+    "sector",
+    "sector_ald",
+    "name",
+    "name_ald",
+    "score",
+    "source",
+    "borderline"
+    )
+
+unexpected_names <- setdiff(names(data), possible_matched_columns)
+
+  if (length(unexpected_names) != 0) {
+    abort(
+      glue("Loanbook has unexpected names: `{unexpected_names}`."),
+      class = "unexpected_names"
+    )
+  }
+
+  invisible(data)
+
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -95,6 +95,8 @@ target_market_share <- function(data,
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 
+  data <- aggregate_by_loan_id(data)
+
   crucial_scenario <- c("scenario", "tmsr", "smsp")
   check_crucial_names(scenario, crucial_scenario)
   check_crucial_names(ald, "is_ultimate_owner")
@@ -383,6 +385,19 @@ reweight_technology_share <- function(data, ...) {
       .x = .data$weighted_technology_share,
       weighted_technology_share = .data$.x / sum(.data$.x),
       .x = NULL
+    ) %>%
+    ungroup()
+}
+
+aggregate_by_loan_id <- function(data) {
+  aggregate_columns <- c("id_loan", "loan_size_outstanding", "loan_size_credit_limit")
+
+  data %>%
+    dplyr::group_by_at(setdiff(names(data), aggregate_columns)) %>%
+    summarize(
+      id_loan = first(.data$id_loan),
+      loan_size_outstanding = sum(.data$loan_size_outstanding),
+      loan_size_credit_limit = sum(.data$loan_size_credit_limit)
     ) %>%
     ungroup()
 }

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -677,29 +677,18 @@ test_that("for one company with multiple loans of different size, unweighted
   expect_equal(projected$production, fake_ald()$production)
 })
 
-test_that("input with extra columns outputs as expected (#267)", {
+test_that("with bad column errors with informative message (#267)", {
 
-  matched <- fake_matched(
-    bad_column = c(1, 2),
-    id_loan = c("L1", "L2")
+  bad_matched <- fake_matched(
+    bad_column = "bad"
   )
 
-  ald <- fake_ald(
-    production = 100
+  expect_error(
+    class = "unexpected_names",
+    target_market_share(
+      bad_matched,
+      fake_ald(),
+      fake_scenario()
+    )
   )
-
-  company_results <- target_market_share(
-    matched,
-    ald,
-    fake_scenario(),
-    region_isos_stable,
-    by_company = TRUE,
-    weight_production = FALSE
-  )
-
-  out <- company_results %>%
-    filter(year == 2025, metric == "projected")
-
-  expect_equal(out$production, 100)
-
 })

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -684,7 +684,7 @@ test_that("with bad column errors with informative message (#267)", {
   )
 
   expect_error(
-    class = "unexpected_names",
+    class = "invalid_columns",
     target_market_share(
       bad_matched,
       fake_ald(),

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -676,3 +676,30 @@ test_that("for one company with multiple loans of different size, unweighted
 
   expect_equal(projected$production, fake_ald()$production)
 })
+
+test_that("input with extra columns outputs as expected (#267)", {
+
+  matched <- fake_matched(
+    bad_column = c(1, 2),
+    id_loan = c("L1", "L2")
+  )
+
+  ald <- fake_ald(
+    production = 100
+  )
+
+  company_results <- target_market_share(
+    matched,
+    ald,
+    fake_scenario(),
+    region_isos_stable,
+    by_company = TRUE,
+    weight_production = FALSE
+  )
+
+  out <- company_results %>%
+    filter(year == 2025, metric == "projected")
+
+  expect_equal(out$production, 100)
+
+})

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -403,7 +403,7 @@ test_that("outputs same names regardless of the value of `weight_production` (#1
   expect_equal(diff_names, character(0))
 })
 
-test_that("with known input outputs `technology_share` as expected (#184)", {
+test_that("with known input outputs `technology_share` as expected (#184, #262)", {
   matched <- fake_matched(
     id_loan = c("L1", "L2"),
     loan_size_outstanding = c(1, 3),
@@ -443,6 +443,76 @@ test_that("with known input outputs `technology_share` as expected (#184)", {
   expect_equal(
     out$target_sds$technology_share,
     c(0.923, 0.076),
+    tolerance = 1e-3
+  )
+
+  ################ More extensive test (#262)
+
+  matched <- fake_matched(
+    id_loan = c("L1", "L2", "L3"),
+    loan_size_outstanding = c(1000, 15000, 1200),
+    name_ald = c("a", "b", "a"),
+    id_2dii = c("DL1", "DL2", "DL1"),
+    sector = "power",
+    sector_ald = "power"
+  )
+
+  ald <- fake_ald(
+    name_company = rep(c("a", "b"), each = 6),
+    sector = "power",
+    technology = rep(
+      c(
+        "coalcap",
+        "gascap",
+        "hydrocap",
+        "nuclearcap",
+        "oilcap",
+        "renewablescap"
+      ),
+      2
+    ),
+    production = c(100, 200, 300, 100, 100, 200, 500, 0, 0, 300, 100, 100),
+    year = 2020
+  )
+
+  scenario <- fake_scenario(
+    sector = "power",
+    technology = c(
+      "coalcap",
+      "gascap",
+      "hydrocap",
+      "nuclearcap",
+      "oilcap",
+      "renewablescap"
+    ),
+    year = 2020,
+    tmsr = 1,
+    smsp = 0
+  )
+
+  out <- target_market_share(
+    matched,
+    ald,
+    scenario,
+    region_isos_stable
+  ) %>%
+    split(.$metric)
+
+  expect_equal(
+    out$projected$technology_share,
+    c(0.4488, 0.0255, 0.0383, 0.2744, 0.1, 0.1128),
+    tolerance = 1e-3
+  )
+
+  expect_equal(
+    out$target_sds$technology_share,
+    c(0.4488, 0.0255, 0.0383, 0.2744, 0.1, 0.1128),
+    tolerance = 1e-3
+  )
+
+  expect_equal(
+    out$corporate_economy$technology_share,
+    c(0.3, 0.1, 0.15, 0.2, 0.1, 0.15),
     tolerance = 1e-3
   )
 })


### PR DESCRIPTION

Closes #267
Thanks for flagging the issue @georgeharris2deg 

I elected to go the more restrictive route since there is some internal aggregations and groupings happening, it's impossible to know arbitrarily how to handle any unexpected column. 

This option will prevent the user from even being able to input unexpected columns, even if they want to. Happy to revisit the decision, but I think it's safest for now. 

