### PR TITLE
Refactor `target_market_share` (#277)

### DIFF
--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -70,7 +70,7 @@ summarize_unweighted_production <- function(data, ...) {
       .data$loan_size_outstanding
     )) %>%
     distinct() %>%
-    group_by(...) %>%
+    group_by(.data$sector_ald, .data$technology, .data$year, ...) %>%
     summarize(weighted_production = sum(.data$production), .groups = "keep") %>%
     ungroup(.data$technology) %>%
     mutate(weighted_technology_share = .data$weighted_production / sum(.data$weighted_production)) %>%

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -382,16 +382,6 @@ maybe_add_name_ald <- function(data, by_company = FALSE) {
   return(out)
 }
 
-maybe_group_by_name_ald <- function(data, ..., by_company = FALSE) {
-  groups <- c(...)
-
-  if (by_company) {
-    groups <- c(groups, "name_ald")
-  }
-
-  group_by(data, !!!rlang::syms(groups))
-}
-
 abort_if_has_list_colums <- function(data) {
   if (has_list_colum(data)) {
     abort("`data` must have no list column.")

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -152,7 +152,8 @@ target_market_share <- function(data,
   if (weight_production) {
     data <- summarize_weighted_production(
       data,
-      !!!rlang::syms(summary_groups)
+      !!!rlang::syms(summary_groups),
+      use_credit_limit = use_credit_limit
     )
 
   } else {

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -127,7 +127,6 @@ target_market_share <- function(data,
   )
 
   check_valid_columns(data, valid_columns)
-  data <- aggregate_by_loan_id(data)
 
   crucial_scenario <- c("scenario", "tmsr", "smsp")
   check_crucial_names(scenario, crucial_scenario)
@@ -135,6 +134,9 @@ target_market_share <- function(data,
   walk_(crucial_scenario, ~ check_no_value_is_missing(scenario, .x))
 
   green_or_brown <- r2dii.data::green_or_brown
+  tmsr_or_smsp <- tmsr_or_smsp()
+
+  data <- aggregate_by_loan_id(data)
 
   summary_groups <- c(
     "scenario",
@@ -202,7 +204,7 @@ target_market_share <- function(data,
       names_to = "target_name",
       values_to = "weighted_production_target"
     ) %>%
-    left_join(tmsr_or_smsp(), by = c(target_name = "which_metric")) %>%
+    left_join(tmsr_or_smsp, by = c(target_name = "which_metric")) %>%
     inner_join(
       green_or_brown,
       by = c(

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -133,8 +133,7 @@ target_market_share <- function(data,
   check_crucial_names(ald, "is_ultimate_owner")
   walk_(crucial_scenario, ~ check_no_value_is_missing(scenario, .x))
 
-  green_or_brown <- r2dii.data::green_or_brown
-  tmsr_or_smsp <- tmsr_or_smsp()
+
 
   data <- aggregate_by_loan_id(data)
 
@@ -182,6 +181,9 @@ target_market_share <- function(data,
     arrange(.data$year) %>%
     group_by(!!!rlang::syms(c(target_groups, "technology"))) %>%
     mutate(initial_technology_production = first(.data$technology_weighted_production))
+
+  green_or_brown <- r2dii.data::green_or_brown
+  tmsr_or_smsp <- tmsr_or_smsp()
 
   data <- data %>%
     mutate(

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -394,7 +394,6 @@ has_list_colum <- function(data) {
   any(vapply(data, is.list, logical(1)))
 }
 
-
 calculate_ald_benchmark <- function(ald, region_isos, by_company) {
   out <- ald %>%
     filter(.data$is_ultimate_owner) %>%

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -214,7 +214,7 @@ target_market_share <- function(data,
     select(-.data$target_name, -.data$green_or_brown)
 
   if (!by_company) {
-    summary_groups <- c(
+    aggregate_company_groups <- c(
       "sector_ald",
       "technology",
       "year",
@@ -224,7 +224,7 @@ target_market_share <- function(data,
       )
 
     data <- data %>%
-      group_by(!!!rlang::syms(summary_groups)) %>%
+      group_by(!!!rlang::syms(aggregate_company_groups)) %>%
       summarize(
         weighted_production = sum(.data$weighted_production),
         weighted_production_target = sum(.data$weighted_production_target),

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -145,7 +145,7 @@ target_market_share <- function(data,
     "region",
     "scenario_source",
     "name_ald"
-    )
+  )
 
   data <- join_ald_scenario(data, ald, scenario, region_isos)
 
@@ -153,7 +153,7 @@ target_market_share <- function(data,
     data <- summarize_weighted_production(
       data,
       !!!rlang::syms(summary_groups)
-      )
+    )
 
   } else {
     data <- summarize_unweighted_production(
@@ -223,7 +223,7 @@ target_market_share <- function(data,
       "scenario",
       "region",
       "scenario_source"
-      )
+    )
 
     data <- data %>%
       group_by(!!!rlang::syms(aggregate_company_groups)) %>%
@@ -237,7 +237,7 @@ target_market_share <- function(data,
   reweighting_groups <- maybe_add_name_ald(
     c("sector_ald", "region", "scenario", "scenario_source", "year"),
     by_company
-    )
+  )
 
   data <- reweight_technology_share(
     data,
@@ -405,7 +405,7 @@ aggregate_by_loan_id <- function(data) {
       .data$loan_size_credit_limit_currency,
       .data$name_ald,
       .data$sector_ald
-      ) %>%
+    ) %>%
     summarize(
       id_loan = first(.data$id_loan),
       loan_size_outstanding = sum(.data$loan_size_outstanding),

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -233,13 +233,7 @@ target_market_share <- function(data,
   }
 
   reweighting_groups <- maybe_add_name_ald(
-    c(
-      "sector_ald",
-      "region",
-      "scenario",
-      "scenario_source",
-      "year"
-    ),
+    c("sector_ald", "region", "scenario", "scenario_source", "year"),
     by_company
     )
 


### PR DESCRIPTION
This PR is strictly refactoring, and should not change the expected functionality of the code whatsoever. Most of the refactoring occurs in `target_market_share`, although I briefly touched `summarize_weighted_production` as I noticed something weird about the interface of the functions. 

The main change can be thought of as follows. Previously, the function `target_market_share()` worked something like this: 
- Join input datasets together
- Add a metric AND summarize (either to company level, or to portfolio level)
- Add targets 
- Tidy-up a bit and output

Now, the function works more like this: 
- Join input datasets together
- Add a metric AND summarize (strictly to company level)
- Add targets 
- Maybe aggregate to portfolio level
- Tidy-up a bit and output

This will make it easier to address the bugfix necessary in #277. 
Relates to #277