### PR TITLE
Dont group_by `level` in `target_market_share()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs `technology_share` with
+  multiple loans at different `level` to the same company (@ab-bbva #265).
+
 # r2dii.analysis 0.1.5
 
 * `target_market_share()` now errors if input `data` has an unexpected column

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -65,7 +65,6 @@ summarize_unweighted_production <- function(data, ...) {
   data %>%
     select(-c(
       .data$id_loan,
-      .data$level,
       .data$loan_size_credit_limit,
       .data$loan_size_outstanding
     )) %>%

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -403,7 +403,6 @@ aggregate_by_loan_id <- function(data) {
 
   data %>%
     group_by(
-      .data$level,
       .data$loan_size_outstanding_currency,
       .data$loan_size_credit_limit_currency,
       .data$name_ald,

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -740,3 +740,58 @@ test_that("`technology_share` outputs consistently when multiple
   expect_equal(out$technology_share, out_split_dl$technology_share)
 
 })
+
+test_that("`technology_share` outputs consistently when multiple
+          loans at different levels match to a single company (#265)", {
+
+            matched_same_level <- fake_matched(
+              id_loan = c("L1", "L2", "L3"),
+              name_direct_loantaker = c("company a1", "company a2", "company b"),
+              name_ald = c("company a", "company a", "company b")
+            )
+
+            matched_diff_level <- matched_same_level %>%
+              mutate(
+                level = c("ultimate_parent", "direct_loantaker", "ultimate_parent")
+              )
+
+            ald <- fake_ald(
+              name_company = rep(c("company a","company b"), each = 2),
+              technology = rep(c("ice", "electric"), 2),
+              production = c(8, 2, 15, 5)
+            )
+
+            scenario <- fake_scenario(
+              technology = c("ice", "electric")
+            )
+
+            out_same_level <- target_market_share(
+              matched_same_level,
+              ald,
+              scenario,
+              region_isos_stable
+            ) %>%
+              filter(
+                metric == "projected",
+                year == 2025,
+                technology == "ice"
+              )
+
+            out_diff_level <- target_market_share(
+              matched_diff_level,
+              ald,
+              scenario,
+              region_isos_stable
+            ) %>%
+              filter(
+                metric == "projected",
+                year == 2025,
+                technology == "ice"
+              )
+
+            expect_equal(
+              out_same_level$technology_share,
+              out_diff_level$technology_share
+              )
+
+          })


### PR DESCRIPTION
The `level` column is only really used in the matching process for calculating coverage statistics. 
In the actual analysis, we should ignore this column. 

Maybe closes #265