### PR TITLE
`technology_share` for `target_*` is now properly calculated and weighted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # r2dii.analysis (development version)
 
-* `target_market_share()` now correctly outputs weighted target technology share 
-  values, in line with methodology.  (@georgeharris2deg #277).
+* `target_market_share()` now correctly outputs target `technology share`, in 
+  line with methodology.  (@georgeharris2deg #277).
 
 * `target_market_share()` now correctly projects technology share as
   'production / total production' when computing by company, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now correctly outputs weighted target technology share 
+  values, in line with methodology.  (@georgeharris2deg #277).
+
 * `target_market_share()` now correctly projects technology share as
   'production / total production' when computing by company, 
   unweighted by relative loan size (@KapitanKombajn #288).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # r2dii.analysis (development version)
 
 * `target_market_share()` now correctly outputs target `technology share`, in 
-  line with methodology.  (@georgeharris2deg #277).
+  line with methodology (@georgeharris2deg #277).
 
 * `target_market_share()` now correctly projects technology share as
   'production / total production' when computing by company, 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -53,7 +53,24 @@
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
-  stopifnot(is.data.frame(data))
+  stopifnot(
+    is.data.frame(data),
+    is.logical(use_credit_limit)
+  )
+
+  crucial <- c(
+    "id_loan",
+    "loan_size_outstanding",
+    "loan_size_outstanding_currency",
+    "loan_size_credit_limit",
+    "loan_size_credit_limit_currency",
+    "sector_ald",
+    "name_ald",
+    "year",
+    "scenario"
+  )
+
+  check_crucial_names(data, crucial)
 
   data %>%
     ungroup() %>%
@@ -121,7 +138,6 @@ summarize_weighted_emission_factor <- function(data, ..., use_credit_limit = FAL
 calculate_weighted_loan_metric <- function(data, metric) {
   crucial <- c(metric, "loan_weight")
 
-  check_crucial_names(data, crucial)
   walk_(crucial, ~ check_no_value_is_missing(data, .x))
 
   data %>%
@@ -144,7 +160,6 @@ add_loan_weight <- function(data, use_credit_limit) {
     "id_loan", "sector_ald", "year", loan_size, currency
   )
 
-  check_crucial_names(data, crucial)
   walk_(crucial, ~ check_no_value_is_missing(data, .x))
 
   old_groups <- dplyr::groups(data)
@@ -166,11 +181,6 @@ add_loan_weight <- function(data, use_credit_limit) {
 }
 
 add_percent_change <- function(data) {
-  crucial <- c("production", "sector_ald", "year", "technology", "scenario")
-
-  check_crucial_names(data, crucial)
-  walk_(crucial, ~ check_no_value_is_missing(data, .x))
-
   check_zero_initial_production(data)
 
   green_or_brown <- r2dii.data::green_or_brown
@@ -200,11 +210,6 @@ add_percent_change <- function(data) {
 }
 
 add_technology_share <- function(data) {
-  crucial <- c("production", "sector_ald", "year", "technology")
-
-  check_crucial_names(data, crucial)
-  walk_(crucial, ~ check_no_value_is_missing(data, .x))
-
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share = .data$production / sum(.data$production)) %>%
@@ -212,11 +217,6 @@ add_technology_share <- function(data) {
 }
 
 add_technology_share_target <- function(data) {
-  crucial <- c("production_target", "sector_ald", "year", "technology")
-
-  check_crucial_names(data, crucial)
-  walk_(crucial, ~ check_no_value_is_missing(data, .x))
-
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share_target = .data$production_target / sum(.data$production_target)) %>%

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -53,24 +53,7 @@
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
-  stopifnot(
-    is.data.frame(data),
-    is.logical(use_credit_limit)
-  )
-
-  crucial <- c(
-    "id_loan",
-    "loan_size_outstanding",
-    "loan_size_outstanding_currency",
-    "loan_size_credit_limit",
-    "loan_size_credit_limit_currency",
-    "sector_ald",
-    "name_ald",
-    "year",
-    "scenario"
-  )
-
-  check_crucial_names(data, crucial)
+  stopifnot(is.data.frame(data))
 
   data %>%
     ungroup() %>%
@@ -138,6 +121,7 @@ summarize_weighted_emission_factor <- function(data, ..., use_credit_limit = FAL
 calculate_weighted_loan_metric <- function(data, metric) {
   crucial <- c(metric, "loan_weight")
 
+  check_crucial_names(data, crucial)
   walk_(crucial, ~ check_no_value_is_missing(data, .x))
 
   data %>%
@@ -160,6 +144,7 @@ add_loan_weight <- function(data, use_credit_limit) {
     "id_loan", "sector_ald", "year", loan_size, currency
   )
 
+  check_crucial_names(data, crucial)
   walk_(crucial, ~ check_no_value_is_missing(data, .x))
 
   old_groups <- dplyr::groups(data)
@@ -181,6 +166,11 @@ add_loan_weight <- function(data, use_credit_limit) {
 }
 
 add_percent_change <- function(data) {
+  crucial <- c("production", "sector_ald", "year", "technology", "scenario")
+
+  check_crucial_names(data, crucial)
+  walk_(crucial, ~ check_no_value_is_missing(data, .x))
+
   check_zero_initial_production(data)
 
   green_or_brown <- r2dii.data::green_or_brown
@@ -210,6 +200,11 @@ add_percent_change <- function(data) {
 }
 
 add_technology_share <- function(data) {
+  crucial <- c("production", "sector_ald", "year", "technology")
+
+  check_crucial_names(data, crucial)
+  walk_(crucial, ~ check_no_value_is_missing(data, .x))
+
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share = .data$production / sum(.data$production)) %>%
@@ -217,6 +212,11 @@ add_technology_share <- function(data) {
 }
 
 add_technology_share_target <- function(data) {
+  crucial <- c("production_target", "sector_ald", "year", "technology")
+
+  check_crucial_names(data, crucial)
+  walk_(crucial, ~ check_no_value_is_missing(data, .x))
+
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share_target = .data$production_target / sum(.data$production_target)) %>%

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -52,7 +52,11 @@
 #' summarize_weighted_percent_change(master)
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
-summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE, add_targets = FALSE) {
+summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
+  summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, add_targets = FALSE)
+}
+
+summarize_weighted_production_ <- function(data, ..., use_credit_limit = FALSE, add_targets = FALSE) {
   stopifnot(is.data.frame(data))
 
   old_groups <- dplyr::groups(data)

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -57,6 +57,15 @@ summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE, a
 
   old_groups <- dplyr::groups(data)
 
+  crucial <- c("production", "sector_ald", "year", "technology")
+
+  if (add_targets) {
+    crucial <- c(crucial, "production_target")
+  }
+
+  check_crucial_names(data, crucial)
+  walk_(crucial, ~ check_no_value_is_missing(data, .x))
+
   data <- data %>%
     ungroup() %>%
     add_loan_weight(use_credit_limit = use_credit_limit) %>%
@@ -247,11 +256,6 @@ add_percent_change <- function(data) {
 }
 
 add_technology_share <- function(data) {
-  crucial <- c("production", "sector_ald", "year", "technology")
-
-  check_crucial_names(data, crucial)
-  walk_(crucial, ~ check_no_value_is_missing(data, .x))
-
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share = .data$production / sum(.data$production)) %>%
@@ -259,11 +263,6 @@ add_technology_share <- function(data) {
 }
 
 add_technology_share_target <- function(data) {
-  crucial <- c("production_target", "sector_ald", "year", "technology")
-
-  check_crucial_names(data, crucial)
-  walk_(crucial, ~ check_no_value_is_missing(data, .x))
-
   data %>%
     group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
     mutate(technology_share_target = .data$production_target / sum(.data$production_target)) %>%

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -68,6 +68,35 @@ summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
     ) %>%
     # Restore old groups
     group_by(!!!dplyr::groups(data))
+
+}
+
+summarize_weighted_production_and_targets <- function(data, ..., use_credit_limit = FALSE) {
+  stopifnot(is.data.frame(data))
+
+  data %>%
+    ungroup() %>%
+    add_loan_weight(use_credit_limit = use_credit_limit) %>%
+    add_technology_share() %>%
+    add_technology_share_target() %>%
+    calculate_weighted_loan_metric("production") %>%
+    calculate_weighted_loan_metric("technology_share") %>%
+    calculate_weighted_loan_metric("production_target") %>%
+    calculate_weighted_loan_metric("technology_share_target") %>%
+    group_by(
+      .data$sector_ald,
+      .data$technology,
+      .data$year,
+      ...
+    ) %>%
+    summarize(
+      weighted_production = sum(.data$weighted_loan_production),
+      weighted_technology_share = sum(.data$weighted_loan_technology_share),
+      weighted_production_target = sum(.data$weighted_loan_production_target),
+      weighted_technology_share_target = sum(.data$weighted_loan_technology_share_target)
+    ) %>%
+    # Restore old groups
+    group_by(!!!dplyr::groups(data))
 }
 
 summarize_unweighted_production <- function(data, ...) {
@@ -83,6 +112,29 @@ summarize_unweighted_production <- function(data, ...) {
     summarize(weighted_production = .data$production, .groups = "keep") %>%
     ungroup(.data$technology, .data$tmsr, .data$smsp) %>%
     mutate(weighted_technology_share = .data$weighted_production / sum(.data$weighted_production)) %>%
+    group_by(!!!dplyr::groups(data))
+}
+
+summarize_unweighted_production_and_targets <- function(data, ...) {
+  data %>%
+    select(-c(
+      .data$id_loan,
+      .data$loan_size_credit_limit,
+      .data$loan_size_outstanding
+    )) %>%
+    distinct() %>%
+    group_by(.data$sector_ald, .data$technology, .data$year, ...) %>%
+    # FIXME: Confusing: `weighted_production` holds unweighted_production?
+    summarize(
+      weighted_production = .data$production,
+      weighted_production_target = .data$production_target,
+      .groups = "keep"
+    ) %>%
+    ungroup(.data$technology) %>%
+    mutate(
+      weighted_technology_share = .data$weighted_production / sum(.data$weighted_production),
+      weighted_technology_share_target = .data$weighted_production_target / sum(.data$weighted_production_target)
+    ) %>%
     group_by(!!!dplyr::groups(data))
 }
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -211,6 +211,18 @@ add_technology_share <- function(data) {
     group_by(!!!dplyr::groups(data))
 }
 
+add_technology_share_target <- function(data) {
+  crucial <- c("production_target", "sector_ald", "year", "technology")
+
+  check_crucial_names(data, crucial)
+  walk_(crucial, ~ check_no_value_is_missing(data, .x))
+
+  data %>%
+    group_by(.data$sector_ald, .data$year, .data$scenario, .data$name_ald) %>%
+    mutate(technology_share_target = .data$production_target / sum(.data$production_target)) %>%
+    group_by(!!!dplyr::groups(data))
+}
+
 check_zero_initial_production <- function(data) {
   companies_with_zero_initial_production <- data %>%
     group_by(.data$technology, .data$name_ald, .data$year) %>%

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -53,17 +53,17 @@
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
-  summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, add_targets = FALSE)
+  summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, with_targets = FALSE)
 }
 
-summarize_weighted_production_ <- function(data, ..., use_credit_limit = FALSE, add_targets = FALSE) {
+summarize_weighted_production_ <- function(data, ..., use_credit_limit = FALSE, with_targets = FALSE) {
   stopifnot(is.data.frame(data))
 
   old_groups <- dplyr::groups(data)
 
   crucial <- c("production", "sector_ald", "year", "technology")
 
-  if (add_targets) {
+  if (with_targets) {
     crucial <- c(crucial, "production_target")
   }
 
@@ -75,7 +75,7 @@ summarize_weighted_production_ <- function(data, ..., use_credit_limit = FALSE, 
     add_loan_weight(use_credit_limit = use_credit_limit) %>%
     add_technology_share()
 
-  if (add_targets) {
+  if (with_targets) {
     data %>%
       add_technology_share_target() %>%
       calculate_weighted_loan_metric("production") %>%
@@ -111,7 +111,7 @@ summarize_weighted_production_ <- function(data, ..., use_credit_limit = FALSE, 
 
 }
 
-summarize_unweighted_production <- function(data, ..., add_targets = FALSE) {
+summarize_unweighted_production <- function(data, ..., with_targets = FALSE) {
   old_groups <- dplyr::groups(data)
 
   data <- data %>%
@@ -124,7 +124,7 @@ summarize_unweighted_production <- function(data, ..., add_targets = FALSE) {
     group_by(.data$sector_ald, .data$technology, .data$year, ...)
     # FIXME: Confusing: `weighted_production` holds unweighted_production?
 
-  if (add_targets) {
+  if (with_targets) {
     data %>%
       summarize(
         weighted_production = .data$production,

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -122,8 +122,10 @@ summarize_unweighted_production <- function(data, ..., with_targets = FALSE) {
     )) %>%
     distinct() %>%
     group_by(.data$sector_ald, .data$technology, .data$year, ...)
-    # FIXME: Confusing: `weighted_production` holds unweighted_production?
 
+  # FIXME: Though production here is unweighted, we still name the variables
+  # `weighted_*`. This is to allow easier reshaping of the output data at the
+  # end of `target_market_share()`.
   if (with_targets) {
     data %>%
       summarize(

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -300,7 +300,7 @@ target_market_share <- function(data,
   ald_with_benchmark <- calculate_ald_benchmark(ald, region_isos, by_company)
 
   data %>%
-    rbind(ald_with_benchmark) %>%
+    dplyr::bind_rows(ald_with_benchmark) %>%
     ungroup()
 }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -160,7 +160,7 @@ target_market_share <- function(data,
   data <- data %>%
     group_by(!!!rlang::syms(crucial_groups)) %>%
     summarize(
-      production = sum(.data$production, rm.na = TRUE)
+      production = sum(.data$production)
     )
 
   if (nrow(data) == 0) {
@@ -288,10 +288,10 @@ target_market_share <- function(data,
     data <- data %>%
       group_by(!!!rlang::syms(aggregate_company_groups)) %>%
       summarize(
-        weighted_production = sum(.data$weighted_production, rm.na = TRUE),
-        weighted_production_target = sum(.data$weighted_production_target, rm.na = TRUE),
-        weighted_technology_share = sum(.data$weighted_technology_share, rm.na = TRUE),
-        weighted_technology_share_target = sum(.data$weighted_technology_share_target, rm.na = TRUE)
+        weighted_production = sum(.data$weighted_production),
+        weighted_production_target = sum(.data$weighted_production_target),
+        weighted_technology_share = sum(.data$weighted_technology_share),
+        weighted_technology_share_target = sum(.data$weighted_technology_share_target)
       )
   }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -233,13 +233,13 @@ target_market_share <- function(data,
       data,
       !!!rlang::syms(summary_groups),
       use_credit_limit = use_credit_limit,
-      add_targets = TRUE
+      with_targets = TRUE
       )
   } else {
     data <- summarize_unweighted_production(
       data,
       !!!rlang::syms(summary_groups),
-      add_targets = TRUE
+      with_targets = TRUE
     )
   }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -229,15 +229,17 @@ target_market_share <- function(data,
   )
 
   if (weight_production) {
-    data <- summarize_weighted_production_and_targets(
+    data <- summarize_weighted_production(
       data,
       !!!rlang::syms(summary_groups),
-      use_credit_limit = use_credit_limit
+      use_credit_limit = use_credit_limit,
+      add_targets = TRUE
       )
   } else {
-    data <- summarize_unweighted_production_and_targets(
+    data <- summarize_unweighted_production(
       data,
-      !!!rlang::syms(summary_groups)
+      !!!rlang::syms(summary_groups),
+      add_targets = TRUE
     )
   }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -243,7 +243,7 @@ target_market_share <- function(data,
         .data$technology,
         .data$year,
         !!!rlang::syms(summary_groups)
-        ) %>%
+      ) %>%
       summarize(
         weighted_production = sum(.data$weighted_loan_production),
         weighted_technology_share = sum(.data$weighted_loan_technology_share),
@@ -266,12 +266,12 @@ target_market_share <- function(data,
         weighted_production = .data$production,
         weighted_production_target = .data$production_target,
         .groups = "keep"
-        ) %>%
+      ) %>%
       ungroup(.data$technology) %>%
       mutate(
         weighted_technology_share = .data$weighted_production / sum(.data$weighted_production),
         weighted_technology_share_target = .data$weighted_production_target / sum(.data$weighted_production_target)
-        ) %>%
+      ) %>%
       group_by(!!!dplyr::groups(data))
   }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -140,6 +140,29 @@ target_market_share <- function(data,
 
   data <- join_ald_scenario(data, ald, scenario, region_isos)
 
+  crucial_groups <- c(
+    "id_loan",
+    "loan_size_outstanding",
+    "loan_size_outstanding_currency",
+    "loan_size_credit_limit",
+    "loan_size_credit_limit_currency",
+    "name_ald",
+    "sector_ald",
+    "technology",
+    "year",
+    "scenario",
+    "region",
+    "tmsr",
+    "smsp",
+    "scenario_source"
+  )
+
+  data <- data %>%
+    group_by(!!!rlang::syms(crucial_groups)) %>%
+    summarize(
+      production = sum(.data$production)
+    )
+
   if (nrow(data) == 0) {
     return(empty_target_market_share_output())
   }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -229,7 +229,7 @@ target_market_share <- function(data,
   )
 
   if (weight_production) {
-    data <- summarize_weighted_production(
+    data <- summarize_weighted_production_(
       data,
       !!!rlang::syms(summary_groups),
       use_credit_limit = use_credit_limit,

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -160,7 +160,7 @@ target_market_share <- function(data,
   data <- data %>%
     group_by(!!!rlang::syms(crucial_groups)) %>%
     summarize(
-      production = sum(.data$production)
+      production = sum(.data$production, rm.na = TRUE)
     )
 
   if (nrow(data) == 0) {
@@ -288,10 +288,10 @@ target_market_share <- function(data,
     data <- data %>%
       group_by(!!!rlang::syms(aggregate_company_groups)) %>%
       summarize(
-        weighted_production = sum(.data$weighted_production),
-        weighted_production_target = sum(.data$weighted_production_target),
-        weighted_technology_share = sum(.data$weighted_technology_share),
-        weighted_technology_share_target = sum(.data$weighted_technology_share_target)
+        weighted_production = sum(.data$weighted_production, rm.na = TRUE),
+        weighted_production_target = sum(.data$weighted_production_target, rm.na = TRUE),
+        weighted_technology_share = sum(.data$weighted_technology_share, rm.na = TRUE),
+        weighted_technology_share_target = sum(.data$weighted_technology_share_target, rm.na = TRUE)
       )
   }
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ to study how their capital allocation impacts the climate.
 
 Before you install r2dii.analysis you may want to:
 
-  - [Try an rstudio.cloud project with this package already
+-   [Try an rstudio.cloud project with this package already
     installed](https://rstudio.cloud/project/1424833).
-  - [Learn how to minimize installation
+-   [Learn how to minimize installation
     errors](https://gist.github.com/maurolepore/a0187be9d40aee95a43f20a85f4caed6#installation).
 
 When you are ready, install the released version of r2dii.analysis from
@@ -50,12 +50,11 @@ issue?](https://2degreesinvesting.github.io/posts/2020-06-26-instructions-to-rai
 
 ## Example
 
-  - Use `library()` to attach the packages you need. r2dii.analysis does
+-   Use `library()` to attach the packages you need. r2dii.analysis does
     not depend on the packages r2dii.data and r2dii.match; but we
-    suggest you install them – with `install.packages(c("r2dii.data",
-    "r2dii.match"))` – so you can reproduce our examples.
-
-<!-- end list -->
+    suggest you install them – with
+    `install.packages(c("r2dii.data", "r2dii.match"))` – so you can
+    reproduce our examples.
 
 ``` r
 library(r2dii.data)
@@ -63,10 +62,8 @@ library(r2dii.match)
 library(r2dii.analysis)
 ```
 
-  - Use `r2dii.match::match_name()` to identify matches between your
+-   Use `r2dii.match::match_name()` to identify matches between your
     loanbook and the asset level data.
-
-<!-- end list -->
 
 ``` r
 matched <- match_name(loanbook_demo, ald_demo) %>%
@@ -75,9 +72,7 @@ matched <- match_name(loanbook_demo, ald_demo) %>%
 
 ### Add Scenario Targets
 
-  - Use `target_sda()` to calculate SDA targets of CO2 emissions.
-
-<!-- end list -->
+-   Use `target_sda()` to calculate SDA targets of CO2 emissions.
 
 ``` r
 matched %>%
@@ -102,10 +97,8 @@ matched %>%
 #> # … with 498 more rows
 ```
 
-  - Use `target_market_share` to calculate market-share scenario targets
+-   Use `target_market_share` to calculate market-share scenario targets
     at the portfolio level:
-
-<!-- end list -->
 
 ``` r
 matched %>%
@@ -130,9 +123,7 @@ matched %>%
 #> # … with 3,632 more rows, and 1 more variable: technology_share <dbl>
 ```
 
-  - Or at the company level:
-
-<!-- end list -->
+-   Or at the company level:
 
 ``` r
 matched %>%
@@ -146,22 +137,20 @@ matched %>%
 #> This will result in company-level results, weighted by the portfolio
 #> loan size, which is rarely useful. Did you mean to set one of these
 #> arguments to `FALSE`?
-#> # A tibble: 14,754 x 11
-#>    sector  technology  year region scenario_source name_ald   sector_weighted_p…
-#>    <chr>   <chr>      <int> <chr>  <chr>           <chr>                   <dbl>
-#>  1 automo… electric    2020 global demo_2020       toyota mo…           4275858.
-#>  2 automo… electric    2020 global demo_2020       toyota mo…           4275858.
-#>  3 automo… electric    2020 global demo_2020       toyota mo…           4275858.
-#>  4 automo… electric    2020 global demo_2020       toyota mo…           4275858.
-#>  5 automo… hybrid      2020 global demo_2020       toyota mo…           4275858.
-#>  6 automo… hybrid      2020 global demo_2020       toyota mo…           4275858.
-#>  7 automo… hybrid      2020 global demo_2020       toyota mo…           4275858.
-#>  8 automo… hybrid      2020 global demo_2020       toyota mo…           4275858.
-#>  9 automo… ice         2020 global demo_2020       toyota mo…           4275858.
-#> 10 automo… ice         2020 global demo_2020       toyota mo…           4275858.
-#> # … with 14,744 more rows, and 4 more variables:
-#> #   technology_weighted_production <dbl>, metric <chr>, production <dbl>,
-#> #   technology_share <dbl>
+#> # A tibble: 14,754 x 9
+#>    sector  technology  year region scenario_source name_ald    metric production
+#>    <chr>   <chr>      <int> <chr>  <chr>           <chr>       <chr>       <dbl>
+#>  1 automo… electric    2020 global demo_2020       toyota mot… proje…    324592.
+#>  2 automo… electric    2020 global demo_2020       toyota mot… targe…    324592.
+#>  3 automo… electric    2020 global demo_2020       toyota mot… targe…    324592.
+#>  4 automo… electric    2020 global demo_2020       toyota mot… targe…    324592.
+#>  5 automo… hybrid      2020 global demo_2020       toyota mot… proje…    628681.
+#>  6 automo… hybrid      2020 global demo_2020       toyota mot… targe…    628681.
+#>  7 automo… hybrid      2020 global demo_2020       toyota mot… targe…    628681.
+#>  8 automo… hybrid      2020 global demo_2020       toyota mot… targe…    628681.
+#>  9 automo… ice         2020 global demo_2020       toyota mot… proje…   3322586.
+#> 10 automo… ice         2020 global demo_2020       toyota mot… targe…   3322586.
+#> # … with 14,744 more rows, and 1 more variable: technology_share <dbl>
 ```
 
 ### Utility Functions
@@ -169,10 +158,8 @@ matched %>%
 The `target_*()` functions provide shortcuts for common operations. They
 wrap some utility functions that you may also use directly:
 
-  - Use `join_ald_scenario()` to join a matched dataset to the relevant
+-   Use `join_ald_scenario()` to join a matched dataset to the relevant
     scenario data, and to pick assets in the relevant regions.
-
-<!-- end list -->
 
 ``` r
 loanbook_joined_to_ald_scenario <- matched %>%
@@ -183,10 +170,8 @@ loanbook_joined_to_ald_scenario <- matched %>%
   )
 ```
 
-  - Use `summarize_weighted_production()` with different grouping
+-   Use `summarize_weighted_production()` with different grouping
     arguments to calculate scenario-targets:
-
-<!-- end list -->
 
 ``` r
 # portfolio level

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -466,7 +466,7 @@ test_that("with known input outputs `technology_share` as expected (#184, #262)"
 
   expect_equal(
     out$target_sds$technology_share,
-    c(0.923, 0.076),
+    c(0.914, 0.086),
     tolerance = 1e-3
   )
 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -201,7 +201,6 @@ test_that("with known input outputs as expected, at company level", {
     production = c(10, 30, 20, 20, 90, 95, 100, 100)
   )
 
-  # FIXME: duplicated entries scenario
   scenario <- fake_scenario(
     technology = c("electric", "ice", "electric", "ice"),
     year = c(2020, 2020, 2021, 2021),

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -201,7 +201,7 @@ test_that("with known input outputs as expected, at company level", {
     production = c(10, 30, 20, 20, 90, 95, 100, 100)
   )
 
-  #FIXME: duplicated entries scenario
+  # FIXME: duplicated entries scenario
   scenario <- fake_scenario(
     technology = c("electric", "ice", "electric", "ice"),
     year = c(2020, 2020, 2021, 2021),
@@ -889,52 +889,51 @@ test_that("projects technology share as 'production / total production' when
 
 test_that("Initial value of technology_share consistent between `projected` and
           `target_*` (#277)", {
+  matched <- fake_matched(
+    id_loan = c("L1", "L2"),
+    name_ald = c("company a", "company b")
+  )
 
-            matched <- fake_matched(
-              id_loan = c("L1", "L2"),
-              name_ald = c("company a", "company b")
-            )
+  ald <- fake_ald(
+    name_company = c("company a", "company b", "company a", "company b"),
+    technology = c("ice", "ice", "electric", "electric"),
+    production = c(100, 1, 100, 3),
+    year = 2020
+  )
 
-            ald <- fake_ald(
-              name_company = c("company a", "company b", "company a", "company b"),
-              technology = c("ice", "ice", "electric", "electric"),
-              production = c(100, 1, 100, 3),
-              year = 2020
-            )
+  scenario <- fake_scenario(
+    technology = c("ice", "electric"),
+    year = 2020,
+    tmsr = 1,
+    smsp = 0
+  )
 
-            scenario <- fake_scenario(
-              technology = c("ice", "electric"),
-              year = 2020,
-              tmsr = 1,
-              smsp = 0
-            )
+  out <- target_market_share(
+    matched,
+    ald,
+    scenario,
+    region_isos_stable
+  ) %>%
+    filter(
+      metric %in% c("projected", "target_sds"),
+      year == 2020
+    ) %>%
+    select(technology, metric, technology_share)
 
-            out <- target_market_share(
-              matched,
-              ald,
-              scenario,
-              region_isos_stable
-              ) %>%
-              filter(
-                metric %in% c("projected", "target_sds"),
-                year == 2020
-              ) %>%
-              select(technology, metric, technology_share)
+  out_ice <- out %>%
+    filter(technology == "ice") %>%
+    split(.$metric)
 
-            out_ice <- out %>%
-              filter(technology == "ice") %>%
-              split(.$metric)
+  out_electric <- out %>%
+    filter(technology == "electric") %>%
+    split(.$metric)
 
-            out_electric <- out %>%
-              filter(technology == "electric") %>%
-              split(.$metric)
-
-            expect_equal(
-              out_ice$projected$technology_share,
-              out_ice$target_sds$technology_share
-              )
-            expect_equal(
-              out_electric$projected$technology_share,
-              out_electric$target_sds$technology_share
-              )
-  })
+  expect_equal(
+    out_ice$projected$technology_share,
+    out_ice$target_sds$technology_share
+  )
+  expect_equal(
+    out_electric$projected$technology_share,
+    out_electric$target_sds$technology_share
+  )
+})


### PR DESCRIPTION
The `target_*` values of `technology_share` should be calculated as follows (in line with the methodology): 
1 - Calculate the `production_target` for each company (without weighting) 
2 - Calculate the `technology_share_target` for each company (without weighting)
3 - Apply the portfolio_weight to each of `production`, `technology_share`, `production_target` and `technology_share_target`

This has been achieved. 
@maurolepore this is an MVP solution, as this has been an open bug for some time. Please review (and note that I recognize that some of my solutions are not so elegant). 

Also @georgeharris2deg if you could please have a look at this it would be much appreciated. 

I would rather we get the solution out the door, and we can refactor later. 

Closes #277
