### PR TITLE
Remove reference to non-existing release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # r2dii.analysis 0.1.8
 
-# r2dii.analysis 0.1.7
-
 * `target_market_share()` now correctly outputs target `technology share`, in 
   line with methodology (@georgeharris2deg #277).
 


### PR DESCRIPTION
My mistake. I forgot to remove a reference to a
version that never made it to CRAN.﻿
