### PR TITLE
`target_market_share` no longer allows for negative `production` targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now never calculates `smsp` targets that are less than 
+  zero (#336). 
+
 * `target_market_share()` now only outputs `sector` values that are present in 
   all of `data`, `ald` and `scenario` (#329). 
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -202,6 +202,13 @@ target_market_share <- function(data,
       smsp_target_production = .data$initial_technology_production +
         (.data$initial_sector_production * .data$smsp)
     ) %>%
+    mutate(
+      smsp_target_production = ifelse(
+        smsp_target_production < 0,
+        0,
+        smsp_target_production
+      )
+    ) %>%
     select(
       -c(
         .data$tmsr,

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -204,9 +204,9 @@ target_market_share <- function(data,
     ) %>%
     mutate(
       smsp_target_production = ifelse(
-        smsp_target_production < 0,
+        .data$smsp_target_production < 0,
         0,
-        smsp_target_production
+        .data$smsp_target_production
       )
     ) %>%
     select(

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -189,7 +189,8 @@ target_market_share <- function(data,
     arrange(.data$year) %>%
     group_by(!!!rlang::syms(c(target_groups, "technology"))) %>%
     mutate(initial_technology_production = first(.data$technology_production)) %>%
-    select(-.data$technology_production)
+    select(-.data$technology_production) %>%
+    ungroup()
 
   green_or_brown <- r2dii.data::green_or_brown
   tmsr_or_smsp <- tmsr_or_smsp()

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -144,7 +144,7 @@ target_market_share <- function(data,
     scenario,
     region_isos,
     add_green_technologies = TRUE
-    )
+  )
 
   crucial_groups <- c(
     "id_loan",

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1128,3 +1128,26 @@ test_that("`target_market_share` only outputs sectors that are present in the
     "automotive"
   )
 })
+
+test_that("`target_market_share` outputs only positive values of `production`(#336)", {
+
+  ald <- fake_ald(
+    year = c(2025, 2026)
+  )
+
+  scenario <- fake_scenario(
+    technology = rep(c("ice", "electric"), 2),
+    smsp = rep(c(0, -1), each = 2),
+    year = rep(c(2025, 2026), each = 2)
+  )
+
+  out <- target_market_share(
+    fake_matched(),
+    ald,
+    scenario,
+    region_isos_stable
+  )
+
+  expect_false(any(out$production < 0))
+
+})

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -970,9 +970,8 @@ test_that("Initial value of technology_share consistent between `projected` and
 
 test_that("Input with only green technologies, outputs only green technologies
           (#318)", {
-
   scenario <- fake_scenario(
-    year = rep(c(2020, 2025),2),
+    year = rep(c(2020, 2025), 2),
     tmsr = c(1, 0.5, 1, 2),
     smsp = c(0, -0.5, 0, 0.5),
     technology = rep(c("ice", "electric"), each = 2),
@@ -997,7 +996,6 @@ test_that("Input with only green technologies, outputs only green technologies
     ),
     character(0)
   )
-
 })
 
 test_that("technology_share is calculated per region (#315)", {
@@ -1041,14 +1039,12 @@ test_that("technology_share is calculated per region (#315)", {
     out$target_sds$technology_share,
     c(0.5, 0.5)
   )
-
 })
 
 test_that("Input with only brown technologies, outputs both green  and brown
           technologies (#318)", {
-
   scenario <- fake_scenario(
-    year = rep(c(2020, 2025),2),
+    year = rep(c(2020, 2025), 2),
     tmsr = c(1, 0.5, 1, 2),
     smsp = c(0, -0.5, 0, 0.5),
     technology = rep(c("ice", "electric"), each = 2),
@@ -1073,11 +1069,9 @@ test_that("Input with only brown technologies, outputs both green  and brown
     ),
     character(0)
   )
-
 })
 
 test_that("Input with unexpected sectors errors gracefully (#329)", {
-
   matched <- fake_matched(
     sector_ald = "a"
   )
@@ -1130,7 +1124,6 @@ test_that("`target_market_share` only outputs sectors that are present in the
 })
 
 test_that("`target_market_share` outputs only positive values of `production`(#336)", {
-
   ald <- fake_ald(
     year = c(2025, 2026)
   )
@@ -1149,5 +1142,4 @@ test_that("`target_market_share` outputs only positive values of `production`(#3
   )
 
   expect_false(any(out$production < 0))
-
 })


### PR DESCRIPTION
Any `smsp` targets that are calculated negatively, will be attenuated to 0. 

This is a **technical** solution but does not solve the larger **methodological** issue, which is to be discussed by the analyst team in the next PACTA bi-weekly. 

Prior to merging this, I would like approval from @georgeharris2deg that he has read and understood this technical interim solution. 

Closes #336