### PR TITLE
Remove companies with no initial sectoral production

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now removes companies from the analysis, if their 
+  initial production is 0 (by `sector` and `plant_location`) (#306 
+  @Antoine-Lalechere, @EvgenyPetrovsky).
+
 * `target_sda()` now filters `scenario` start year to be consistent with `ald` 
   start year (#346 @waltjl). 
 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1143,3 +1143,20 @@ test_that("`target_market_share` outputs only positive values of `production`(#3
 
   expect_false(any(out$production < 0))
 })
+
+test_that("Outputs, with warning, for input companies with no initial sectoral
+          production (ADO876)", {
+  ald <- fake_ald(
+    year = c(2020, 2021),
+    production = c(0, 1)
+  )
+
+  scenario <- fake_scenario(
+    year = c(2020, 2021)
+  )
+
+  expect_warning(
+    target_market_share(fake_matched(), ald, scenario, region_isos_stable),
+    class = "has_no_initial_sectoral_production"
+  )
+})


### PR DESCRIPTION
This PR: 
* Determines the start year of the analysis (defined here by the earliest year in `scenario` input)
* Removes companies from the `ald` input, if their production at the start year is 0 (by `sector` and `plant_location`)
* Warns the user if any companies are actually removed

Closes #306 
Supercedes #348 