### PR TITLE
Set `technology_share` to 0 for companies with zero initial sectoral production

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_market_share()` now outputs 0 `technology_share`, for companies with 
+  0 sectoral production (#306 @Antoine-Lalechere). 
+
 * `target_sda()` now filters `scenario` start year to be consistent with `ald` 
   start year (#346 @waltjl). 
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -269,7 +269,11 @@ add_technology_share <- function(data) {
       .data$name_ald,
       .data$region
     ) %>%
-    mutate(technology_share = .data$production / sum(.data$production)) %>%
+    mutate(
+      .x = sum(.data$production),
+      technology_share = ifelse(.data$.x == 0, 0, .data$production / .data$.x),
+      .x = NULL
+      ) %>%
     group_by(!!!dplyr::groups(data))
 }
 
@@ -282,7 +286,11 @@ add_technology_share_target <- function(data) {
       .data$name_ald,
       .data$region
     ) %>%
-    mutate(technology_share_target = .data$production_target / sum(.data$production_target)) %>%
+    mutate(
+      .x = sum(.data$production_target),
+      technology_share_target = ifelse(.data$.x == 0, 0, .data$production_target / .data$.x),
+      .x = NULL
+      ) %>%
     group_by(!!!dplyr::groups(data))
 }
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -273,7 +273,7 @@ add_technology_share <- function(data) {
       .x = sum(.data$production),
       technology_share = ifelse(.data$.x == 0, 0, .data$production / .data$.x),
       .x = NULL
-      ) %>%
+    ) %>%
     group_by(!!!dplyr::groups(data))
 }
 
@@ -290,7 +290,7 @@ add_technology_share_target <- function(data) {
       .x = sum(.data$production_target),
       technology_share_target = ifelse(.data$.x == 0, 0, .data$production_target / .data$.x),
       .x = NULL
-      ) %>%
+    ) %>%
     group_by(!!!dplyr::groups(data))
 }
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -402,8 +402,8 @@ calculate_ald_benchmark <- function(ald, region_isos, by_company) {
       .data$sector, .data$year, .data$region, .data$source
     ) %>%
     mutate(
-      .x = .data$production,
-      technology_share = .data$.x / sum(.data$.x),
+      .x = sum(.data$production),
+      technology_share = ifelse(.data$.x == 0, 0, .data$production / .data$.x),
       .x = NULL,
       metric = "corporate_economy"
     ) %>%
@@ -437,11 +437,15 @@ reweight_technology_share <- function(data, ...) {
     group_by(...) %>%
     mutate(
       .x = .data$weighted_technology_share,
+      .sum_x = sum(.data$.x),
       .y = .data$weighted_technology_share_target,
-      weighted_technology_share = .data$.x / sum(.data$.x),
-      weighted_technology_share_target = .data$.y / sum(.data$.y),
+      .sum_y = sum(.data$.y),
+      weighted_technology_share = ifelse(.data$.sum_x == 0, 0, .data$.x / .data$.sum_x),
+      weighted_technology_share_target = ifelse(.data$.sum_y == 0, 0, .data$.y / .data$.sum_y),
       .x = NULL,
-      .y = NULL
+      .sum_x = NULL,
+      .y = NULL,
+      .sum_y = NULL
     ) %>%
     ungroup()
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -440,8 +440,16 @@ reweight_technology_share <- function(data, ...) {
       .sum_x = sum(.data$.x),
       .y = .data$weighted_technology_share_target,
       .sum_y = sum(.data$.y),
-      weighted_technology_share = ifelse(.data$.sum_x == 0, 0, .data$.x / .data$.sum_x),
-      weighted_technology_share_target = ifelse(.data$.sum_y == 0, 0, .data$.y / .data$.sum_y),
+      weighted_technology_share = ifelse(
+        .data$.sum_x == 0,
+        0,
+        .data$.x / .data$.sum_x
+        ),
+      weighted_technology_share_target = ifelse(
+        .data$.sum_y == 0,
+        0,
+        .data$.y / .data$.sum_y
+        ),
       .x = NULL,
       .sum_x = NULL,
       .y = NULL,

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -436,24 +436,20 @@ reweight_technology_share <- function(data, ...) {
   data %>%
     group_by(...) %>%
     mutate(
-      .x = .data$weighted_technology_share,
-      .sum_x = sum(.data$.x),
-      .y = .data$weighted_technology_share_target,
-      .sum_y = sum(.data$.y),
+      .x = sum(.data$weighted_technology_share),
+      .y = sum(.data$weighted_technology_share_target),
       weighted_technology_share = ifelse(
-        .data$.sum_x == 0,
+        .data$.x == 0,
         0,
-        .data$.x / .data$.sum_x
+        .data$weighted_technology_share / .data$.x
         ),
       weighted_technology_share_target = ifelse(
-        .data$.sum_y == 0,
+        .data$.y == 0,
         0,
-        .data$.y / .data$.sum_y
+        .data$weighted_technology_share_target / .data$.y
         ),
       .x = NULL,
-      .sum_x = NULL,
       .y = NULL,
-      .sum_y = NULL
     ) %>%
     ungroup()
 }

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1145,9 +1145,8 @@ test_that("`target_market_share` outputs only positive values of `production`(#3
 })
 
 test_that("`target_market_share` outputs as expected for companies with 0 initial sectoral production (#306)", {
-
   ald <- fake_ald(
-    production = c(0,1),
+    production = c(0, 1),
     year = c(2020, 2021)
   )
 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1144,7 +1144,8 @@ test_that("`target_market_share` outputs only positive values of `production`(#3
   expect_false(any(out$production < 0))
 })
 
-test_that("`target_market_share` outputs as expected for companies with 0 initial sectoral production (#306)", {
+test_that("`target_market_share` outputs as expected for companies with 0
+          initial sectoral production (#306)", {
   ald <- fake_ald(
     production = c(0, 1),
     year = c(2020, 2021)

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1143,3 +1143,35 @@ test_that("`target_market_share` outputs only positive values of `production`(#3
 
   expect_false(any(out$production < 0))
 })
+
+test_that("`target_market_share` outputs as expected for companies with 0 initial sectoral production (#306)", {
+
+  ald <- fake_ald(
+    production = c(0,1),
+    year = c(2020, 2021)
+  )
+
+  scenario <- fake_scenario(
+    tmsr = c(1, 0.5),
+    year = c(2020, 2021)
+  )
+
+  out <- target_market_share(
+    fake_matched(),
+    ald,
+    scenario,
+    region_isos_stable
+  ) %>%
+    arrange(.$year) %>%
+    split(.$metric)
+
+
+  expect_equal(out$corporate_economy$production, c(0, 1))
+  expect_equal(out$projected$production, c(0, 1))
+  expect_equal(out$target_sds$production, c(0, 0))
+
+
+  expect_equal(out$corporate_economy$technology_share, c(0, 1))
+  expect_equal(out$projected$technology_share, c(0, 1))
+  expect_equal(out$target_sds$technology_share, c(0, 0))
+})


### PR DESCRIPTION
This PR is a sparse implementation of @Antoine-Lalechere's fix to set `technology_share` values to `0` should they have no initial sectoral production (#348). 

Closes #306 
Closes [ADO 876](https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/876)