### PR TITLE
MERGE 2nd: Make sysdata reproducible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Imports:
     rlang,
     tidyr,
     tidyselect,
-    withr,
     zoo
 Suggests: 
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
     rlang,
     tidyr,
     tidyselect,
+    withr,
     zoo
 Suggests: 
     covr,
@@ -50,8 +51,8 @@ Suggests:
     roxygen2,
     spelling,
     testthat (>= 3.0.0)
+Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Config/testthat/edition: 3

--- a/data-raw/sysdata.R
+++ b/data-raw/sysdata.R
@@ -9,7 +9,7 @@ library(fs)
 library(withr)
 
 # Access older version of r2dii.data without changing current version
-temp_lib <- tempdir()
+temp_lib <- local_tempdir()
 fs::dir_create(temp_lib)
 
 withr::with_libpaths(temp_lib, {
@@ -24,6 +24,9 @@ region_isos_stable <- region_isos_demo
 nace_classification <- nace_classification %>%
   select(.data$code, .data$sector, .data$borderline)
 
+loanbook_demo <- loanbook_demo %>%
+  mutate(across(.data$sector_classification_direct_loantaker, as.character))
+
 loanbook_stable <- left_join(
   loanbook_demo, nace_classification,
   by = c(sector_classification_direct_loantaker = "code")
@@ -35,5 +38,3 @@ usethis::use_data(
   internal = TRUE,
   overwrite = TRUE
 )
-
-fs::dir_delete(temp_lib)


### PR DESCRIPTION
This PR merges not into master but into 354_*, which is
a way to say it depends on #354.

Closes #353

When I tried to source data-raw/sysdata.R I got an error,
showing that sysdata was no longer reproducible. This pr
makes sysdata reproducible again, by ensuring two columns
we want to join by of the same type.

