### PR TITLE
Remove CI tests from testthat

### DIFF
--- a/R/join_ald_scenario.R
+++ b/R/join_ald_scenario.R
@@ -5,7 +5,7 @@
 #' the analysis.
 #'
 #' @param data A data frame like the output of
-#'   [r2dii.match::prioritize()].
+#'   `r2dii.match::prioritize`.
 #' @param ald An asset level data frame like [r2dii.data::ald_demo].
 #' @param scenario A scenario data frame like [r2dii.data::scenario_demo_2020].
 #' @param region_isos A data frame like [r2dii.data::region_isos] (default).
@@ -23,8 +23,8 @@
 #' @examples
 #' installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
 #'   requireNamespace("r2dii.match", quietly = TRUE)
-#' if (!installed) stop("Please install r2dii.match and r2dii.data")
 #'
+#' if (installed) {
 #' library(r2dii.data)
 #' library(r2dii.match)
 #'
@@ -38,6 +38,8 @@
 #'     scenario = scenario_demo_2020,
 #'     region_isos = region_isos_demo
 #'   )
+#' }
+#'
 join_ald_scenario <- function(data,
                               ald,
                               scenario,

--- a/R/join_ald_scenario.R
+++ b/R/join_ald_scenario.R
@@ -25,21 +25,20 @@
 #'   requireNamespace("r2dii.match", quietly = TRUE)
 #'
 #' if (installed) {
-#' library(r2dii.data)
-#' library(r2dii.match)
+#'   library(r2dii.data)
+#'   library(r2dii.match)
 #'
-#' valid_matches <- match_name(loanbook_demo, ald_demo) %>%
-#'   # WARNING: Remember to validate matches (see `?prioritize`)
-#'   prioritize()
+#'   valid_matches <- match_name(loanbook_demo, ald_demo) %>%
+#'     # WARNING: Remember to validate matches (see `?prioritize`)
+#'     prioritize()
 #'
-#' valid_matches %>%
-#'   join_ald_scenario(
-#'     ald = ald_demo,
-#'     scenario = scenario_demo_2020,
-#'     region_isos = region_isos_demo
-#'   )
+#'   valid_matches %>%
+#'     join_ald_scenario(
+#'       ald = ald_demo,
+#'       scenario = scenario_demo_2020,
+#'       region_isos = region_isos_demo
+#'     )
 #' }
-#'
 join_ald_scenario <- function(data,
                               ald,
                               scenario,

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -30,29 +30,28 @@
 #' installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
 #'   requireNamespace("r2dii.match", quietly = TRUE)
 #' if (installed) {
-#' library(r2dii.data)
-#' library(r2dii.match)
+#'   library(r2dii.data)
+#'   library(r2dii.match)
 #'
-#' loanbook <- head(loanbook_demo, 150)
-#' ald <- head(ald_demo, 100)
-#' master <- loanbook %>%
-#'   match_name(ald) %>%
-#'   prioritize() %>%
-#'   join_ald_scenario(
-#'     ald = ald,
-#'     scenario = scenario_demo_2020,
-#'     region_isos = region_isos_demo
-#'   )
+#'   loanbook <- head(loanbook_demo, 150)
+#'   ald <- head(ald_demo, 100)
+#'   master <- loanbook %>%
+#'     match_name(ald) %>%
+#'     prioritize() %>%
+#'     join_ald_scenario(
+#'       ald = ald,
+#'       scenario = scenario_demo_2020,
+#'       region_isos = region_isos_demo
+#'     )
 #'
-#' summarize_weighted_production(master)
+#'   summarize_weighted_production(master)
 #'
-#' summarize_weighted_production(master, use_credit_limit = TRUE)
+#'   summarize_weighted_production(master, use_credit_limit = TRUE)
 #'
-#' summarize_weighted_percent_change(master)
+#'   summarize_weighted_percent_change(master)
 #'
-#' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
+#'   summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 #' }
-
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
   summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, with_targets = FALSE)
 }

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -29,8 +29,7 @@
 #' @examples
 #' installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
 #'   requireNamespace("r2dii.match", quietly = TRUE)
-#' if (!installed) stop("Please install r2dii.match and r2dii.data")
-#'
+#' if (installed) {
 #' library(r2dii.data)
 #' library(r2dii.match)
 #'
@@ -52,6 +51,8 @@
 #' summarize_weighted_percent_change(master)
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
+#' }
+
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
   summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, with_targets = FALSE)
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -32,44 +32,42 @@
 #'   requireNamespace("r2dii.match", quietly = TRUE)
 #'
 #' if (installed) {
+#'   library(r2dii.data)
+#'   library(r2dii.match)
 #'
-#' library(r2dii.data)
-#' library(r2dii.match)
+#'   loanbook <- head(loanbook_demo, 100)
+#'   ald <- head(ald_demo, 100)
 #'
-#' loanbook <- head(loanbook_demo, 100)
-#' ald <- head(ald_demo, 100)
+#'   matched <- loanbook %>%
+#'     match_name(ald) %>%
+#'     prioritize()
 #'
-#' matched <- loanbook %>%
-#'   match_name(ald) %>%
-#'   prioritize()
+#'   # Calculate targets at portfolio level
+#'   matched %>%
+#'     target_market_share(
+#'       ald = ald,
+#'       scenario = scenario_demo_2020,
+#'       region_isos = region_isos_demo
+#'     )
 #'
-#' # Calculate targets at portfolio level
-#' matched %>%
-#'   target_market_share(
-#'     ald = ald,
-#'     scenario = scenario_demo_2020,
-#'     region_isos = region_isos_demo
-#'   )
+#'   # Calculate targets at company level
+#'   matched %>%
+#'     target_market_share(
+#'       ald = ald,
+#'       scenario = scenario_demo_2020,
+#'       region_isos = region_isos_demo,
+#'       by_company = TRUE
+#'     )
 #'
-#' # Calculate targets at company level
-#' matched %>%
-#'   target_market_share(
-#'     ald = ald,
-#'     scenario = scenario_demo_2020,
-#'     region_isos = region_isos_demo,
-#'     by_company = TRUE
-#'   )
-#'
-#' matched %>%
-#'   target_market_share(
-#'     ald = ald,
-#'     scenario = scenario_demo_2020,
-#'     region_isos = region_isos_demo,
-#'     # Calculate unweighted targets
-#'     weight_production = FALSE
-#'   )
+#'   matched %>%
+#'     target_market_share(
+#'       ald = ald,
+#'       scenario = scenario_demo_2020,
+#'       region_isos = region_isos_demo,
+#'       # Calculate unweighted targets
+#'       weight_production = FALSE
+#'     )
 #' }
-
 target_market_share <- function(data,
                                 ald,
                                 scenario,
@@ -444,12 +442,12 @@ reweight_technology_share <- function(data, ...) {
         .data$.x == 0,
         0,
         .data$weighted_technology_share / .data$.x
-        ),
+      ),
       weighted_technology_share_target = ifelse(
         .data$.y == 0,
         0,
         .data$weighted_technology_share_target / .data$.y
-        ),
+      ),
       .x = NULL,
       .y = NULL,
     ) %>%

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -6,8 +6,7 @@
 #'
 #' @template ignores-existing-groups
 #'
-#' @param data A "data.frame" like the output of
-#'   [r2dii.match::prioritize()].
+#' @param data A "data.frame" like the output of `r2dii.match::prioritize`.
 #' @param ald An asset level data frame like [r2dii.data::ald_demo].
 #' @param scenario A scenario data frame like [r2dii.data::scenario_demo_2020].
 #' @param region_isos A data frame like [r2dii.data::region_isos] (default).
@@ -31,7 +30,8 @@
 #' @examples
 #' installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
 #'   requireNamespace("r2dii.match", quietly = TRUE)
-#' if (!installed) stop("Please install r2dii.match and r2dii.data")
+#'
+#' if (installed) {
 #'
 #' library(r2dii.data)
 #' library(r2dii.match)
@@ -68,6 +68,8 @@
 #'     # Calculate unweighted targets
 #'     weight_production = FALSE
 #'   )
+#' }
+
 target_market_share <- function(data,
                                 ald,
                                 scenario,

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -35,45 +35,43 @@
 #' installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
 #'   requireNamespace("r2dii.data", quietly = TRUE)
 #' if (installed) {
-#' library(r2dii.match)
-#' library(r2dii.data)
+#'   library(r2dii.match)
+#'   library(r2dii.data)
 #'
-#' # Example datasets from r2dii.data
-#' loanbook <- head(loanbook_demo, 150)
-#' ald <- head(ald_demo, 100)
+#'   # Example datasets from r2dii.data
+#'   loanbook <- head(loanbook_demo, 150)
+#'   ald <- head(ald_demo, 100)
 #'
-#' co2_scenario <- co2_intensity_scenario_demo
+#'   co2_scenario <- co2_intensity_scenario_demo
 #'
-#' # WARNING: Remember to validate matches (see `?prioritize`)
-#' matched <- prioritize(match_name(loanbook, ald))
+#'   # WARNING: Remember to validate matches (see `?prioritize`)
+#'   matched <- prioritize(match_name(loanbook, ald))
 #'
-#' # You may need to clean your data
-#' anyNA(ald$emission_factor)
-#' try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
+#'   # You may need to clean your data
+#'   anyNA(ald$emission_factor)
+#'   try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
 #'
-#' ald2 <- subset(ald, !is.na(emission_factor))
-#' anyNA(ald2$emission_factor)
+#'   ald2 <- subset(ald, !is.na(emission_factor))
+#'   anyNA(ald2$emission_factor)
 #'
-#' out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
+#'   out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
 #'
-#' # The output includes the portfolio's actual projected emissions factors, the
-#' # scenario pathway emissions factors, and the portfolio's target emissions
-#' # factors.
-#' out
+#'   # The output includes the portfolio's actual projected emissions factors, the
+#'   # scenario pathway emissions factors, and the portfolio's target emissions
+#'   # factors.
+#'   out
 #'
-#' # Split-view by metric
-#' split(out, out$emission_factor_metric)
+#'   # Split-view by metric
+#'   split(out, out$emission_factor_metric)
 #'
-#' # Calculate company-level targets
-#' out <- target_sda(
-#'   matched, ald2,
-#'   co2_intensity_scenario = co2_scenario,
-#'   by_company = TRUE
-#' )
-#' out
+#'   # Calculate company-level targets
+#'   out <- target_sda(
+#'     matched, ald2,
+#'     co2_intensity_scenario = co2_scenario,
+#'     by_company = TRUE
+#'   )
+#'   out
 #' }
-#'
-
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -10,7 +10,7 @@
 #' @template ignores-existing-groups
 #'
 #' @param data A dataframe like the output of
-#'   [r2dii.match::prioritize()].
+#'   `r2dii.match::prioritize()`.
 #' @param ald An asset-level data frame like [r2dii.data::ald_demo].
 #' @param co2_intensity_scenario A scenario data frame like
 #'   [r2dii.data::co2_intensity_scenario_demo].
@@ -34,8 +34,7 @@
 #' @examples
 #' installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
 #'   requireNamespace("r2dii.data", quietly = TRUE)
-#' if (!installed) stop("Please install r2dii.match and r2dii.data")
-#'
+#' if (installed) {
 #' library(r2dii.match)
 #' library(r2dii.data)
 #'
@@ -72,6 +71,9 @@
 #'   by_company = TRUE
 #' )
 #' out
+#' }
+#'
+
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,

--- a/man/join_ald_scenario.Rd
+++ b/man/join_ald_scenario.Rd
@@ -14,7 +14,7 @@ join_ald_scenario(
 }
 \arguments{
 \item{data}{A data frame like the output of
-\code{\link[r2dii.match:prioritize]{r2dii.match::prioritize()}}.}
+\code{r2dii.match::prioritize}.}
 
 \item{ald}{An asset level data frame like \link[r2dii.data:ald_demo]{r2dii.data::ald_demo}.}
 
@@ -39,8 +39,8 @@ the analysis.
 \examples{
 installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
-if (!installed) stop("Please install r2dii.match and r2dii.data")
 
+if (installed) {
 library(r2dii.data)
 library(r2dii.match)
 
@@ -54,6 +54,8 @@ valid_matches \%>\%
     scenario = scenario_demo_2020,
     region_isos = region_isos_demo
   )
+}
+
 }
 \seealso{
 Other utility functions: 

--- a/man/join_ald_scenario.Rd
+++ b/man/join_ald_scenario.Rd
@@ -41,21 +41,20 @@ installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
 
 if (installed) {
-library(r2dii.data)
-library(r2dii.match)
+  library(r2dii.data)
+  library(r2dii.match)
 
-valid_matches <- match_name(loanbook_demo, ald_demo) \%>\%
-  # WARNING: Remember to validate matches (see `?prioritize`)
-  prioritize()
+  valid_matches <- match_name(loanbook_demo, ald_demo) \%>\%
+    # WARNING: Remember to validate matches (see `?prioritize`)
+    prioritize()
 
-valid_matches \%>\%
-  join_ald_scenario(
-    ald = ald_demo,
-    scenario = scenario_demo_2020,
-    region_isos = region_isos_demo
-  )
+  valid_matches \%>\%
+    join_ald_scenario(
+      ald = ald_demo,
+      scenario = scenario_demo_2020,
+      region_isos = region_isos_demo
+    )
 }
-
 }
 \seealso{
 Other utility functions: 

--- a/man/summarize_weighted_production.Rd
+++ b/man/summarize_weighted_production.Rd
@@ -40,27 +40,27 @@ companies would cause percent-change percentage to be infinite, which is wrong.
 installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
 if (installed) {
-library(r2dii.data)
-library(r2dii.match)
+  library(r2dii.data)
+  library(r2dii.match)
 
-loanbook <- head(loanbook_demo, 150)
-ald <- head(ald_demo, 100)
-master <- loanbook \%>\%
-  match_name(ald) \%>\%
-  prioritize() \%>\%
-  join_ald_scenario(
-    ald = ald,
-    scenario = scenario_demo_2020,
-    region_isos = region_isos_demo
-  )
+  loanbook <- head(loanbook_demo, 150)
+  ald <- head(ald_demo, 100)
+  master <- loanbook \%>\%
+    match_name(ald) \%>\%
+    prioritize() \%>\%
+    join_ald_scenario(
+      ald = ald,
+      scenario = scenario_demo_2020,
+      region_isos = region_isos_demo
+    )
 
-summarize_weighted_production(master)
+  summarize_weighted_production(master)
 
-summarize_weighted_production(master, use_credit_limit = TRUE)
+  summarize_weighted_production(master, use_credit_limit = TRUE)
 
-summarize_weighted_percent_change(master)
+  summarize_weighted_percent_change(master)
 
-summarize_weighted_percent_change(master, use_credit_limit = TRUE)
+  summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 }
 }
 \seealso{

--- a/man/summarize_weighted_production.Rd
+++ b/man/summarize_weighted_production.Rd
@@ -39,8 +39,7 @@ companies would cause percent-change percentage to be infinite, which is wrong.
 \examples{
 installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
-if (!installed) stop("Please install r2dii.match and r2dii.data")
-
+if (installed) {
 library(r2dii.data)
 library(r2dii.match)
 
@@ -62,6 +61,7 @@ summarize_weighted_production(master, use_credit_limit = TRUE)
 summarize_weighted_percent_change(master)
 
 summarize_weighted_percent_change(master, use_credit_limit = TRUE)
+}
 }
 \seealso{
 \code{\link[=join_ald_scenario]{join_ald_scenario()}}.

--- a/man/target_market_share.Rd
+++ b/man/target_market_share.Rd
@@ -55,42 +55,41 @@ installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
 
 if (installed) {
+  library(r2dii.data)
+  library(r2dii.match)
 
-library(r2dii.data)
-library(r2dii.match)
+  loanbook <- head(loanbook_demo, 100)
+  ald <- head(ald_demo, 100)
 
-loanbook <- head(loanbook_demo, 100)
-ald <- head(ald_demo, 100)
+  matched <- loanbook \%>\%
+    match_name(ald) \%>\%
+    prioritize()
 
-matched <- loanbook \%>\%
-  match_name(ald) \%>\%
-  prioritize()
+  # Calculate targets at portfolio level
+  matched \%>\%
+    target_market_share(
+      ald = ald,
+      scenario = scenario_demo_2020,
+      region_isos = region_isos_demo
+    )
 
-# Calculate targets at portfolio level
-matched \%>\%
-  target_market_share(
-    ald = ald,
-    scenario = scenario_demo_2020,
-    region_isos = region_isos_demo
-  )
+  # Calculate targets at company level
+  matched \%>\%
+    target_market_share(
+      ald = ald,
+      scenario = scenario_demo_2020,
+      region_isos = region_isos_demo,
+      by_company = TRUE
+    )
 
-# Calculate targets at company level
-matched \%>\%
-  target_market_share(
-    ald = ald,
-    scenario = scenario_demo_2020,
-    region_isos = region_isos_demo,
-    by_company = TRUE
-  )
-
-matched \%>\%
-  target_market_share(
-    ald = ald,
-    scenario = scenario_demo_2020,
-    region_isos = region_isos_demo,
-    # Calculate unweighted targets
-    weight_production = FALSE
-  )
+  matched \%>\%
+    target_market_share(
+      ald = ald,
+      scenario = scenario_demo_2020,
+      region_isos = region_isos_demo,
+      # Calculate unweighted targets
+      weight_production = FALSE
+    )
 }
 }
 \seealso{

--- a/man/target_market_share.Rd
+++ b/man/target_market_share.Rd
@@ -15,8 +15,7 @@ target_market_share(
 )
 }
 \arguments{
-\item{data}{A "data.frame" like the output of
-\code{\link[r2dii.match:prioritize]{r2dii.match::prioritize()}}.}
+\item{data}{A "data.frame" like the output of \code{r2dii.match::prioritize}.}
 
 \item{ald}{An asset level data frame like \link[r2dii.data:ald_demo]{r2dii.data::ald_demo}.}
 
@@ -54,7 +53,8 @@ This function ignores existing groups and outputs ungrouped data.
 \examples{
 installed <- requireNamespace("r2dii.data", quietly = TRUE) &&
   requireNamespace("r2dii.match", quietly = TRUE)
-if (!installed) stop("Please install r2dii.match and r2dii.data")
+
+if (installed) {
 
 library(r2dii.data)
 library(r2dii.match)
@@ -91,6 +91,7 @@ matched \%>\%
     # Calculate unweighted targets
     weight_production = FALSE
   )
+}
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -52,44 +52,43 @@ This function ignores existing groups and outputs ungrouped data.
 installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
   requireNamespace("r2dii.data", quietly = TRUE)
 if (installed) {
-library(r2dii.match)
-library(r2dii.data)
+  library(r2dii.match)
+  library(r2dii.data)
 
-# Example datasets from r2dii.data
-loanbook <- head(loanbook_demo, 150)
-ald <- head(ald_demo, 100)
+  # Example datasets from r2dii.data
+  loanbook <- head(loanbook_demo, 150)
+  ald <- head(ald_demo, 100)
 
-co2_scenario <- co2_intensity_scenario_demo
+  co2_scenario <- co2_intensity_scenario_demo
 
-# WARNING: Remember to validate matches (see `?prioritize`)
-matched <- prioritize(match_name(loanbook, ald))
+  # WARNING: Remember to validate matches (see `?prioritize`)
+  matched <- prioritize(match_name(loanbook, ald))
 
-# You may need to clean your data
-anyNA(ald$emission_factor)
-try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
+  # You may need to clean your data
+  anyNA(ald$emission_factor)
+  try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
 
-ald2 <- subset(ald, !is.na(emission_factor))
-anyNA(ald2$emission_factor)
+  ald2 <- subset(ald, !is.na(emission_factor))
+  anyNA(ald2$emission_factor)
 
-out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
+  out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
 
-# The output includes the portfolio's actual projected emissions factors, the
-# scenario pathway emissions factors, and the portfolio's target emissions
-# factors.
-out
+  # The output includes the portfolio's actual projected emissions factors, the
+  # scenario pathway emissions factors, and the portfolio's target emissions
+  # factors.
+  out
 
-# Split-view by metric
-split(out, out$emission_factor_metric)
+  # Split-view by metric
+  split(out, out$emission_factor_metric)
 
-# Calculate company-level targets
-out <- target_sda(
-  matched, ald2,
-  co2_intensity_scenario = co2_scenario,
-  by_company = TRUE
-)
-out
+  # Calculate company-level targets
+  out <- target_sda(
+    matched, ald2,
+    co2_intensity_scenario = co2_scenario,
+    by_company = TRUE
+  )
+  out
 }
-
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -15,7 +15,7 @@ target_sda(
 }
 \arguments{
 \item{data}{A dataframe like the output of
-\code{\link[r2dii.match:prioritize]{r2dii.match::prioritize()}}.}
+\code{r2dii.match::prioritize()}.}
 
 \item{ald}{An asset-level data frame like \link[r2dii.data:ald_demo]{r2dii.data::ald_demo}.}
 
@@ -51,8 +51,7 @@ This function ignores existing groups and outputs ungrouped data.
 \examples{
 installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
   requireNamespace("r2dii.data", quietly = TRUE)
-if (!installed) stop("Please install r2dii.match and r2dii.data")
-
+if (installed) {
 library(r2dii.match)
 library(r2dii.data)
 
@@ -89,6 +88,8 @@ out <- target_sda(
   by_company = TRUE
 )
 out
+}
+
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/tests/testthat/test-join_ald_scenario.R
+++ b/tests/testthat/test-join_ald_scenario.R
@@ -1,6 +1,5 @@
 library(dplyr)
 library(r2dii.data)
-library(r2dii.match)
 
 test_that("with fake data outputs known value", {
   out <- join_ald_scenario(
@@ -246,28 +245,9 @@ test_that("include/excludes `plant_location` inside/outside a region", {
 })
 
 test_that("outputs the same with upper/lower ald$sector or ald$technology", {
-  # From r2dii.match fake_lbk()
-  lbk <- tibble(
-    sector_classification_system = "NACE",
-    id_ultimate_parent = "UP15",
-    name_ultimate_parent = "Alpine Knits India Pvt. Limited",
-    id_direct_loantaker = "C294",
-    name_direct_loantaker = "Yuamen Xinneng Thermal Power Co Ltd",
-    sector_classification_direct_loantaker = 3511,
-    id_loan = 1
-  )
-  # Based on r2dii.match fake_ald()
-  ald <- tibble(
-    name_company = "alpine knits india pvt. limited",
-    sector = "power",
-    alias_ald = "alpineknitsindiapvt ltd",
-    plant_location = "dm",
-    technology = "renewablescap",
-    year = 2020
-  )
-  matched <- prioritize(match_name(lbk, ald))
-
-  scenario <- r2dii.data::scenario_demo_2020
+  matched <- fake_matched()
+  ald <- fake_ald()
+  scenario <- fake_scenario()
   regions <- region_isos_stable
 
   out_lower <- join_ald_scenario(matched, ald, scenario, regions)

--- a/tests/testthat/test-summarize_weighted_production.R
+++ b/tests/testthat/test-summarize_weighted_production.R
@@ -1,5 +1,4 @@
 library(r2dii.data)
-library(r2dii.match)
 
 # Production --------------------------------------------------------------
 
@@ -185,38 +184,6 @@ test_that("preserves groups passed to ...", {
   expect_equal(dplyr::group_vars(out), "plant_location")
 })
 
-test_that("with demo data returns known value", {
-  allows_reserved_columns <- exists(
-    "allow_reserved_columns",
-    where = asNamespace("r2dii.match"),
-    mode = "function"
-  )
-  skip_if_not(allows_reserved_columns)
-
-  restore <- options(r2dii.match.allow_reserved_columns = TRUE)
-  on.exit(options(restore), add = TRUE)
-
-  master <- prioritize(match_name(loanbook_stable, ald_demo)) %>%
-    join_ald_scenario(
-      ald = ald_demo,
-      scenario = scenario_demo_2020,
-      region_isos = region_isos_stable
-    )
-
-  credit_limit0 <- summarize_weighted_production(master)
-  file0 <- "ref-summarize_weighted_production-credit_limit0"
-  expect_known_value(credit_limit0, file0, update = FALSE)
-  # Clearer output when this test fails
-  expect_equal(readRDS(test_path(file0)), credit_limit0)
-
-  credit_limit1 <- master %>%
-    summarize_weighted_production(use_credit_limit = TRUE)
-  file1 <- "ref-summarize_weighted_production-credit_limit1"
-  expect_known_value(credit_limit1, file1, update = FALSE)
-  # Clearer output when this test fails
-  expect_equal(readRDS(test_path(file1)), credit_limit1)
-})
-
 # Percent-change ---------------------------------------------------------------
 
 test_that("with bad `data` errors with informative message", {
@@ -388,38 +355,6 @@ test_that("with zero initial production errors with informative message", {
     class = "zero_initial_production",
     summarize_weighted_percent_change(data)
   )
-})
-
-test_that("with demo data returns known value", {
-  allows_reserved_columns <- exists(
-    "allow_reserved_columns",
-    where = asNamespace("r2dii.match"),
-    mode = "function"
-  )
-  skip_if_not(allows_reserved_columns)
-
-  restore <- options(r2dii.match.allow_reserved_columns = TRUE)
-  on.exit(options(restore), add = TRUE)
-
-  master <- prioritize(match_name(loanbook_stable, ald_demo)) %>%
-    join_ald_scenario(
-      ald = ald_demo,
-      scenario = scenario_demo_2020,
-      region_isos = region_isos_stable
-    )
-
-  credit_limit0 <- summarize_weighted_percent_change(master)
-  file0 <- "ref-summarize_weighted_percent_change-credit_limit0"
-  expect_known_value(credit_limit0, file0, update = FALSE)
-  # Clearer output when this test fails
-  expect_equal(readRDS(test_path(file0)), credit_limit0)
-
-  credit_limit1 <- master %>%
-    summarize_weighted_percent_change(use_credit_limit = TRUE)
-  file1 <- "ref-summarize_weighted_percent_change-credit_limit1"
-  expect_known_value(credit_limit1, file1, update = FALSE)
-  # Clearer output when this test fails
-  expect_equal(readRDS(test_path(file1)), credit_limit1)
 })
 
 test_that("with known input outputs as expected", {

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -1,6 +1,5 @@
-library(r2dii.data)
-library(r2dii.match)
 library(dplyr)
+library(r2dii.data)
 
 test_that("with fake data outputs known value", {
   out <- target_sda(

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -616,4 +616,3 @@ test_that("doesn't output NAs if ald and scenario years are misaligned (#307,
     any(is.na(out$emission_factor_value))
   )
 })
-


### PR DESCRIPTION
Closes #356

Background: CRAN archived r2dii.analysis becuase of an issue that indirectly relates to r2dii.match. This PR avoids failures on CRAN when r2dii.match is unavailable. 
