### PR TITLE
Update GH actions to render README on push and pr

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,7 +1,12 @@
 on:
   push:
-    paths:
-      - README.Rmd
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
 
 name: Render README
 


### PR DESCRIPTION
This PR aims to compensate for the CI tests that were removed in #360. 

By rendering the `README` file, that runs the entire "PACTA for banks workflow", with dummy data using `r2dii.data` and `r2dii.match`, we test on every PR if the changes to `r2dii.analysis` would be compatible with the upstream packages. 

Closes #361