### PR TITLE
Add return values for pipe and tidyeval

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     glue,
     magrittr,
     r2dii.data,
-    rlang,
+    rlang (>= 0.1.2),
     tidyr,
     tidyselect,
     zoo

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -8,6 +8,7 @@
 #' @export
 #' @importFrom magrittr %>%
 #' @usage lhs \%>\% rhs
+#' @param lhs A value or the magrittr placeholder.
+#' @param rhs A function call using the magrittr semantics.
+#' @return The result of calling `rhs(lhs)`.
 NULL
-
-globalVariables(".")

--- a/R/utils-tidy-eval.R
+++ b/R/utils-tidy-eval.R
@@ -1,6 +1,42 @@
 #' Tidy eval helpers
 #'
-#' See <https://dplyr.tidyverse.org/reference/tidyeval.html>.
+#' To learn more about tidy eval and how to use these tools, visit
+#' \url{https://tidyeval.tidyverse.org} and the
+#' \href{https://adv-r.hadley.nz/metaprogramming.html}{Metaprogramming
+#' section} of \href{https://adv-r.hadley.nz}{Advanced R}.
+#'
+#' @return
+#'
+#' * \code{\link[rlang]{sym}()} creates a symbol from a string and
+#'   \code{\link[rlang:sym]{syms}()} creates a list of symbols from a
+#'   character vector.
+#'
+#' * \code{\link[rlang:nse-defuse]{enquo}()} and
+#'   \code{\link[rlang:nse-defuse]{enquos}()} delay the execution of one or
+#'   several function arguments. \code{enquo()} returns a single quoted
+#'   expression, which is like a blueprint for the delayed computation.
+#'   \code{enquos()} returns a list of such quoted expressions.
+#'
+#' * \code{\link[rlang:nse-defuse]{expr}()} quotes a new expression _locally_. It
+#'   is mostly useful to build new expressions around arguments
+#'   captured with [enquo()] or [enquos()]:
+#'   \code{expr(mean(!!enquo(arg), na.rm = TRUE))}.
+#'
+#' * \code{\link[rlang]{as_name}()} transforms a quoted variable name
+#'   into a string. Supplying something else than a quoted variable
+#'   name is an error.
+#'
+#'   That's unlike \code{\link[rlang]{as_label}()} which also returns
+#'   a single string but supports any kind of R object as input,
+#'   including quoted function calls and vectors. Its purpose is to
+#'   summarise that object into a single label. That label is often
+#'   suitable as a default name.
+#'
+#'   If you don't know what a quoted expression contains (for instance
+#'   expressions captured with \code{enquo()} could be a variable
+#'   name, a call to a function, or an unquoted constant), then use
+#'   \code{as_label()}. If you know you have quoted a simple variable
+#'   name, or would like to enforce this, use \code{as_name()}.
 #'
 #' @md
 #' @name tidyeval

--- a/man/pipe.Rd
+++ b/man/pipe.Rd
@@ -6,6 +6,14 @@
 \usage{
 lhs \%>\% rhs
 }
+\arguments{
+\item{lhs}{A value or the magrittr placeholder.}
+
+\item{rhs}{A function call using the magrittr semantics.}
+}
+\value{
+The result of calling \code{rhs(lhs)}.
+}
 \description{
 See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
 }

--- a/man/tidyeval.Rd
+++ b/man/tidyeval.Rd
@@ -12,7 +12,41 @@
 \alias{as_name}
 \alias{as_label}
 \title{Tidy eval helpers}
+\value{
+\itemize{
+\item \code{\link[rlang]{sym}()} creates a symbol from a string and
+\code{\link[rlang:sym]{syms}()} creates a list of symbols from a
+character vector.
+\item \code{\link[rlang:nse-defuse]{enquo}()} and
+\code{\link[rlang:nse-defuse]{enquos}()} delay the execution of one or
+several function arguments. \code{enquo()} returns a single quoted
+expression, which is like a blueprint for the delayed computation.
+\code{enquos()} returns a list of such quoted expressions.
+\item \code{\link[rlang:nse-defuse]{expr}()} quotes a new expression \emph{locally}. It
+is mostly useful to build new expressions around arguments
+captured with \code{\link[=enquo]{enquo()}} or \code{\link[=enquos]{enquos()}}:
+\code{expr(mean(!!enquo(arg), na.rm = TRUE))}.
+\item \code{\link[rlang]{as_name}()} transforms a quoted variable name
+into a string. Supplying something else than a quoted variable
+name is an error.
+
+That's unlike \code{\link[rlang]{as_label}()} which also returns
+a single string but supports any kind of R object as input,
+including quoted function calls and vectors. Its purpose is to
+summarise that object into a single label. That label is often
+suitable as a default name.
+
+If you don't know what a quoted expression contains (for instance
+expressions captured with \code{enquo()} could be a variable
+name, a call to a function, or an unquoted constant), then use
+\code{as_label()}. If you know you have quoted a simple variable
+name, or would like to enforce this, use \code{as_name()}.
+}
+}
 \description{
-See \url{https://dplyr.tidyverse.org/reference/tidyeval.html}.
+To learn more about tidy eval and how to use these tools, visit
+\url{https://tidyeval.tidyverse.org} and the
+\href{https://adv-r.hadley.nz/metaprogramming.html}{Metaprogramming
+section} of \href{https://adv-r.hadley.nz}{Advanced R}.
 }
 \keyword{internal}


### PR DESCRIPTION
Complements #367 

I updated usethis and rerun `use_pipe()` and `use_tidyevel()` hoping the latest version of usethis would add `@return` to those helpfiles. That was the case for pipe but not for tidyeval. 

- Document return value of the pipe via the development version of `usethis::use_pipe()` 
- Run `usethis::use_tidyeval()` plus move things around a bit and add `@return` to meet CRAN's requirement.

I'm still unsure what's the recommended way to deal with this. I searched on rOpenSci's slack and found nothing useful. We may come across some other way but for now this should work.
