### PR TITLE
Simpler News

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -43,15 +43,7 @@ navbar:
       href: articles/production-percent-change.html
 
   - text: "News"
-    menu:
-    - text: "Releases"
-    - text: "Version 0.1.0"
-      href: https://2degreesinvesting.github.io/posts/2020-09-08-r2dii-analysis-0-1-0-is-now-on-cran/
-    - text: "Version 0.0.1"
-      href: https://2degreesinvesting.github.io/posts/2020-06-29-r2dii-analysis-0-0-1/
-    - text: "----------------------"
-    - text: "Change log"
-      href: news/index.html
+    href: news/index.html
 
   right:
     - text: "Packages"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -43,7 +43,12 @@ navbar:
       href: articles/production-percent-change.html
 
   - text: "News"
-    href: news/index.html
+    menu:
+    - text: "r2dii blog posts"
+      href: https://2degreesinvesting.github.io/#category:r2dii
+    - text: "----------------------"
+    - text: "Change log"
+      href: news/index.html
 
   right:
     - text: "Packages"


### PR DESCRIPTION
The News menu has a "Releases" section that I now find confusing
because there are more releases than entries under News/Releases,
pointing to external articles. But we don't write articles for
most small patches.

This PR removes the headings "Releases" and "Changelog", to
instead expose the changelog directly under the News navbar.

The goal is to reduce confusion and to reduce maintenance cost,
by not feeling we need to add an article for small patches. 

An alternative could be to add a single link to the blog, so
users can discover it and then serve themselves what they 
need. 

--

Relates to similar PRs in other r2dii packages (e.g. https://github.com/2DegreesInvesting/r2dii.match/pull/382) but we can discuss only here and then I can apply the decision to all repos.
