### PR TITLE
Ensure `target_market_share` only outputs entries for years that exist in both `ald` and `scenario` input

### DIFF
--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -196,10 +196,12 @@ target_market_share <- function(data,
   corporate_economy <- calculate_ald_benchmark(ald, region_isos, by_company)
 
   sectors_with_data <- unique(data$sector)
+  years_in_data <- unique(data$year)
 
   relevant_corporate_economy <- filter(
     corporate_economy,
-    .data$sector %in% sectors_with_data
+    .data$sector %in% sectors_with_data,
+    .data$year %in% years_in_data
   )
 
   data <- data %>%

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1323,7 +1323,8 @@ test_that("w/ known input, outputs `percent_of_initial_production_by_scope` as
   )
 })
 
-test_that("w/ ald input with start year prior to ", {
+test_that("w/ ald with older years than scenarios, outputs 0 percent change in
+          start year", {
   ald <- fake_ald(
     year = c(2000, 2020, 2021),
     production = c(10, 30, 40)
@@ -1343,9 +1344,28 @@ test_that("w/ ald input with start year prior to ", {
     region_isos_stable,
     by_company = FALSE,
     weight_production = FALSE
-  ) %>%
-    filter(metric == "corporate_economy")
+  )
 
   expect_equal(min(out$year), 2020L)
+
+  initial_out <- out %>%
+    filter(year == 2020L)
+
+  initial_out <- split(initial_out, initial_out$metric)
+
+  expect_equal(
+    initial_out$corporate_economy$percentage_of_initial_production_by_scope,
+    0L
+    )
+
+  expect_equal(
+    initial_out$projected$percentage_of_initial_production_by_scope,
+    0L
+  )
+
+  expect_equal(
+    initial_out$target_sds$percentage_of_initial_production_by_scope,
+    0L
+  )
 
 })

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1322,3 +1322,30 @@ test_that("w/ known input, outputs `percent_of_initial_production_by_scope` as
     tolerance = 1e-2
   )
 })
+
+test_that("w/ ald input with start year prior to ", {
+  ald <- fake_ald(
+    year = c(2000, 2020, 2021),
+    production = c(10, 30, 40)
+  )
+
+  scenario <- fake_scenario(
+    technology = "ice",
+    year = c(2020, 2021),
+    tmsr = c(1, 0.6),
+    smsp = c(0, -0.2)
+  )
+
+  out <- target_market_share(
+    fake_matched(),
+    ald,
+    scenario,
+    region_isos_stable,
+    by_company = FALSE,
+    weight_production = FALSE
+  ) %>%
+    filter(metric == "corporate_economy")
+
+  expect_equal(min(out$year), 2020L)
+
+})


### PR DESCRIPTION
Closes #394