### PR TITLE
`target_sda` now outputs unweighted `emission_factor` by default, if `by_company = TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # r2dii.analysis (development version)
 
+* `target_sda()` now outputs unweighted `emission_factor` by default, if 
+  `by_company` is `TRUE` (#394). 
+
 * `target_market_share()` now outputs two new columns, `percentage_of_initial_production_by_scope` 
 and `scope` (ADO #4143). 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # r2dii.analysis (development version)
 
-* `target_sda()` now outputs unweighted `emission_factor` by default, if 
-  `by_company` is `TRUE` (#394). 
+* `target_sda()` now outputs unweighted `emission_factor` if `by_company` is 
+  `TRUE` (#376). 
 
 * `target_market_share()` now outputs two new columns, `percentage_of_initial_production_by_scope` 
 and `scope` (ADO #4143). 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -180,7 +180,6 @@ summarize_weighted_emission_factor <- function(data, ..., use_credit_limit = FAL
 }
 
 summarize_unweighted_emission_factor <- function(data, ...) {
-
   data <- data %>%
     select(-c(
       .data$id_loan,
@@ -191,7 +190,6 @@ summarize_unweighted_emission_factor <- function(data, ...) {
     group_by(.data$sector_ald, .data$year, ...) %>%
     summarize(emission_factor_projected = mean(.data$emission_factor)) %>%
     ungroup()
-
 }
 
 calculate_weighted_loan_metric <- function(data, metric) {

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -179,6 +179,21 @@ summarize_weighted_emission_factor <- function(data, ..., use_credit_limit = FAL
     ungroup()
 }
 
+summarize_unweighted_emission_factor <- function(data, ...) {
+
+  data <- data %>%
+    select(-c(
+      .data$id_loan,
+      .data$loan_size_credit_limit,
+      .data$loan_size_outstanding
+    )) %>%
+    distinct() %>%
+    group_by(.data$sector_ald, .data$technology, .data$year, ...) %>%
+    summarize(emission_factor_projected = mean(.data$weighted_loan_emission_factor)) %>%
+    ungroup()
+
+}
+
 calculate_weighted_loan_metric <- function(data, metric) {
   crucial <- c(metric, "loan_weight")
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -188,8 +188,8 @@ summarize_unweighted_emission_factor <- function(data, ...) {
       .data$loan_size_outstanding
     )) %>%
     distinct() %>%
-    group_by(.data$sector_ald, .data$technology, .data$year, ...) %>%
-    summarize(emission_factor_projected = mean(.data$weighted_loan_emission_factor)) %>%
+    group_by(.data$sector_ald, .data$year, ...) %>%
+    summarize(emission_factor_projected = mean(.data$emission_factor)) %>%
     ungroup()
 
 }

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -86,16 +86,7 @@ target_market_share <- function(data,
     is.logical(weight_production)
   )
 
-  if (by_company & weight_production) {
-    warn(
-      glue(
-        "You've supplied `by_company = TRUE` and `weight_production = TRUE`.
-        This will result in company-level results, weighted by the portfolio
-        loan size, which is rarely useful. Did you mean to set one of these
-        arguments to `FALSE`?"
-      )
-    )
-  }
+  warn_if_by_company_and_weight_production(by_company, weight_production)
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -91,6 +91,8 @@ target_sda <- function(data,
     is.logical(by_company)
   )
 
+  warn_if_by_company_and_weight_production(by_company, weight_production)
+
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 
   crucial_portfolio <- c(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -20,6 +20,10 @@
 #' @param by_company Logical vector of length 1. `FALSE` defaults to outputting
 #'   `weighted_production_value` at the portfolio-level. Set to `TRUE` to output
 #'   `weighted_production_value` at the company-level.
+#' @param weight_emission_factor Logical vector of length 1. `TRUE` defaults to
+#'   outputting emission_factor, weighted by relative loan-size. Set to `FALSE`
+#'   to output the unweighted emission_factor values.
+#'
 #'
 #' @return  A tibble with the CO2 emissions factors attributed to
 #' the portfolio. These values include the portfolio's actual projected CO2
@@ -76,7 +80,8 @@ target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,
                        use_credit_limit = FALSE,
-                       by_company = FALSE) {
+                       by_company = FALSE,
+                       weight_emission_factor = TRUE) {
   stopifnot(
     is.data.frame(data),
     is.data.frame(ald),

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -137,16 +137,12 @@ target_sda <- function(data,
 
   data <- inner_join(data, ald_by_sector, by = ald_columns())
 
-  if (!by_company) {
-    data <- summarize_weighted_emission_factor(
-      data,
-      use_credit_limit = use_credit_limit,
-    )
+  if (by_company) {
+    data <- data %>%
+      summarize_unweighted_emission_factor(!!!rlang::syms("name_ald"))
   } else {
-    data <- summarize_unweighted_emission_factor(
-      data,
-      !!!rlang::syms("name_ald")
-    )
+    data <- data %>%
+      summarize_weighted_emission_factor(use_credit_limit = use_credit_limit)
   }
 
   data <- data %>%

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -156,10 +156,9 @@ target_sda <- function(data,
 
   if (by_company) {
     data <- data %>%
-      summarize_weighted_emission_factor(
-        !!!rlang::syms(c(summary_groups, "name_ald")),
-        use_credit_limit = use_credit_limit
-      )
+      summarize_unweighted_emission_factor(
+        !!!rlang::syms(c(summary_groups, "name_ald"))
+        )
   } else {
     data <- data %>%
       summarize_weighted_emission_factor(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -21,7 +21,6 @@
 #'   `weighted_production_value` at the portfolio-level. Set to `TRUE` to output
 #'   `weighted_production_value` at the company-level.
 #'
-#'
 #' @return  A tibble with the CO2 emissions factors attributed to
 #' the portfolio. These values include the portfolio's actual projected CO2
 #' emissions factors, the scenario pathway CO2 emissions factors and the SDA

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -87,10 +87,6 @@ target_sda <- function(data,
     is.logical(by_company)
   )
 
-  if (by_company) {
-    weight_emission_factor <- FALSE
-  }
-
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 
   crucial_portfolio <- c(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -141,10 +141,9 @@ target_sda <- function(data,
 
   data <- inner_join(data, ald_by_sector, by = ald_columns())
 
-  if (weight_emission_factor) {
+  if (!by_company) {
     data <- summarize_weighted_emission_factor(
       data,
-      !!!rlang::syms("name_ald"),
       use_credit_limit = use_credit_limit,
     )
   } else {
@@ -152,20 +151,6 @@ target_sda <- function(data,
       data,
       !!!rlang::syms("name_ald")
     )
-  }
-
-  if (!by_company) {
-    aggregate_company_groups <- c(
-      "sector_ald",
-      "year"
-    )
-
-    data <- data %>%
-      group_by(!!!rlang::syms(aggregate_company_groups)) %>%
-      summarize(
-        emission_factor_projected = mean(.data$emission_factor_projected)
-      ) %>%
-      ungroup()
   }
 
   data <- data %>%

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -91,11 +91,6 @@ target_sda <- function(data,
     weight_emission_factor <- FALSE
   }
 
-  warn_if_by_company_and_weight_production(
-    by_company,
-    weight_emission_factor
-    )
-
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))
 
   crucial_portfolio <- c(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -73,7 +73,7 @@
 #'   )
 #'   out
 #' }
-
+#'
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,
@@ -201,7 +201,7 @@ target_sda <- function(data,
 
 check_type_emission_factor <- function(ald) {
   if (!is.double(ald$emission_factor)) {
-  abort("The column emission_factor of the asset-level data frame (`ald`) does not have the type double", class = "crucial_column_wrong_type")
+    abort("The column emission_factor of the asset-level data frame (`ald`) does not have the type double", class = "crucial_column_wrong_type")
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,6 +15,20 @@ warn_grouped <- function(data, message) {
   invisible(data)
 }
 
+warn_if_by_company_and_weight_production <- function(by_company,
+                                                     weight_production) {
+  if (by_company & weight_production) {
+    warn(
+      glue(
+        "You've supplied `by_company = TRUE` and `weight_production = TRUE`.
+        This will result in company-level results, weighted by the portfolio
+        loan size, which is rarely useful. Did you mean to set one of these
+        arguments to `FALSE`?"
+      )
+    )
+  }
+}
+
 # Avoid dependency on purrr
 walk_ <- function(.x, .f, ...) {
   .f <- rlang::as_function(.f)

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -89,6 +89,7 @@ if (installed) {
   )
   out
 }
+
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -488,7 +488,7 @@ test_that("w/ known input, outputs `technology_share` as expected (#184, #262)",
     c(0.6875, 0.3125)
   )
 
-  FIXME <- 1e-2  # Do we need 1e-3?
+  FIXME <- 1e-2 # Do we need 1e-3?
   expect_equal(
     out$corporate_economy$technology_share,
     c(0.666, 0.333),

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -34,8 +34,7 @@ test_that("with fake data outputs known value", {
       year = c(2020, 2050),
       emission_factor = c(0.6, 0.2)
     ),
-    by_company = TRUE,
-    weight_emission_factor = FALSE
+    by_company = TRUE
   )
 
   expect_snapshot(out_company)
@@ -654,8 +653,7 @@ test_that("argument `weight_emission_factor` outputs correctly with known input 
     target_sda(
       ald,
       fake_co2_scenario(year = c(2020, 2021), emission_factor = c(1, 0.7)),
-      by_company = TRUE,
-      weight_emission_factor = FALSE
+      by_company = TRUE
     ) %>%
     filter(year == 2020, emission_factor_metric == "target_b2ds") %>%
     split(.$name_ald)

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -34,7 +34,8 @@ test_that("with fake data outputs known value", {
       year = c(2020, 2050),
       emission_factor = c(0.6, 0.2)
     ),
-    by_company = TRUE
+    by_company = TRUE,
+    weight_emission_factor = FALSE
   )
 
   expect_snapshot(out_company)

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -671,7 +671,7 @@ test_that("argument `weight_emission_factor` outputs correctly with known input 
     )
 
   expect_equal(
-    out$`american cement`$emission_factor_value,
+    out$`boral cement`$emission_factor_value,
     ald$`boral cement`$emission_factor
   )
 })

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -717,7 +717,8 @@ test_that("argument `weight_emission_factor` outputs correctly with known input 
     target_sda(
       ald,
       fake_co2_scenario(year = c(2020, 2021), emission_factor = c(1, 0.7)),
-      by_company = TRUE
+      by_company = TRUE,
+      region_isos = region_isos_stable
     ) %>%
     filter(year == 2020, emission_factor_metric == "target_b2ds") %>%
     split(.$name_ald)

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -667,7 +667,7 @@ test_that("argument `weight_emission_factor` outputs correctly with known input 
   expect_equal(
     out$`american cement`$emission_factor_value,
     ald$`american cement`$emission_factor
-    )
+  )
 
   expect_equal(
     out$`boral cement`$emission_factor_value,


### PR DESCRIPTION
Now:
* `target_sda(..., by_company = FALSE)` will calculate the loan-weighted emission factors, and aggregate them to portfolio level
* `target_sda(..., by_company = TRUE)` will output unweighted emission factors, and output them at company level

Note that the function `target_market_share()` has the argument `weight_production` which allows the user to manually control this behavior. I have elected not to include an analogous `weight_emission_factor` argument in this function, as the weighted but un-aggregated `emission_factor` value is not really interpretable or useful for the user, and would likely just cause confusion. 

Closes #376 