### PR TITLE
`target_sda` gains `region_isos` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # r2dii.analysis (development version)
+* `target_sda()` gains `region` argument (#323).
 
 * `target_market_share()` now only outputs values for years that are in both 
   `ald` and `scenario` inputs (#394). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # r2dii.analysis (development version)
-* `target_sda()` gains `region` argument (#323).
+* `target_sda()` gains `region_isos` argument (#323).
 
 * `target_market_share()` now only outputs values for years that are in both 
   `ald` and `scenario` inputs (#394). 

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -22,11 +22,9 @@
 #'   `weighted_production_value` at the portfolio-level. Set to `TRUE` to output
 #'   `weighted_production_value` at the company-level.
 #'
-#' @return  A tibble with the CO2 emissions factors attributed to
-#' the portfolio. These values include the portfolio's actual projected CO2
-#' emissions factors, the scenario pathway CO2 emissions factors and the SDA
-#' calculated portfolio target emissions factors (see column
-#' `emission_factor_metric`).
+#' @return A tibble including the summarized columns `emission_factor_metric` and
+#'   `emission_factor_value`. If `by_company = TRUE`, the output will also have
+#'   the column `name_ald`.
 #'
 #' @export
 #'
@@ -77,9 +75,9 @@
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,
-                       region_isos = r2dii.data::region_isos,
                        use_credit_limit = FALSE,
-                       by_company = FALSE) {
+                       by_company = FALSE,
+                       region_isos = r2dii.data::region_isos) {
   stopifnot(
     is.data.frame(data),
     is.data.frame(ald),

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -73,7 +73,7 @@
 #'   )
 #'   out
 #' }
-
+#'
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,
@@ -159,7 +159,7 @@ target_sda <- function(data,
   if (by_company) {
     data <- data %>%
       summarize_weighted_emission_factor(
-        !!!rlang::syms(c(summary_groups,"name_ald")),
+        !!!rlang::syms(c(summary_groups, "name_ald")),
         use_credit_limit = use_credit_limit
       )
   } else {
@@ -226,7 +226,7 @@ target_sda <- function(data,
 
 check_type_emission_factor <- function(ald) {
   if (!is.double(ald$emission_factor)) {
-  abort("The column emission_factor of the asset-level data frame (`ald`) does not have the type double", class = "crucial_column_wrong_type")
+    abort("The column emission_factor of the asset-level data frame (`ald`) does not have the type double", class = "crucial_column_wrong_type")
   }
 }
 
@@ -296,14 +296,15 @@ compute_ald_adjusted_scenario <- function(data, corporate_economy) {
   data %>%
     filter(.data$year >= min(corporate_economy$year)) %>%
     inner_join(
-      corporate_economy_baseline, by = c("sector", "scenario_source", "region")
-      ) %>%
+      corporate_economy_baseline,
+      by = c("sector", "scenario_source", "region")
+    ) %>%
     group_by(
       .data$scenario,
       .data$sector,
       .data$scenario_source,
       .data$region
-      ) %>%
+    ) %>%
     arrange(.data$year) %>%
     mutate(
       baseline_adjustment =
@@ -331,7 +332,7 @@ add_p_to_scenario <- function(data) {
       .data$scenario,
       .data$region,
       .data$scenario_source
-      ) %>%
+    ) %>%
     arrange(.data$year) %>%
     mutate(p = p(.data$emission_factor_adjusted_scenario)) %>%
     ungroup()
@@ -344,7 +345,7 @@ compute_loanbook_targets <- function(data,
     right_join(
       scenario_with_p,
       by = c("year", "sector", "region", "scenario_source")
-      ) %>%
+    ) %>%
     group_by(...) %>%
     arrange(.data$year) %>%
     mutate(

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -14,6 +14,7 @@
 #' @param ald An asset-level data frame like [r2dii.data::ald_demo].
 #' @param co2_intensity_scenario A scenario data frame like
 #'   [r2dii.data::co2_intensity_scenario_demo].
+#' @param region_isos A data frame like [r2dii.data::region_isos] (default).
 #' @param use_credit_limit Logical vector of length 1. `FALSE` defaults to using
 #'   the column `loan_size_outstanding`. Set to `TRUE` to instead use the column
 #'   `loan_size_credit_limit`.
@@ -76,6 +77,7 @@
 target_sda <- function(data,
                        ald,
                        co2_intensity_scenario,
+                       region_isos = r2dii.data::region_isos,
                        use_credit_limit = FALSE,
                        by_company = FALSE) {
   stopifnot(

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -9,6 +9,7 @@ target_sda(
   data,
   ald,
   co2_intensity_scenario,
+  region_isos = r2dii.data::region_isos,
   use_credit_limit = FALSE,
   by_company = FALSE
 )
@@ -21,6 +22,8 @@ target_sda(
 
 \item{co2_intensity_scenario}{A scenario data frame like
 \link[r2dii.data:co2_intensity_scenario_demo]{r2dii.data::co2_intensity_scenario_demo}.}
+
+\item{region_isos}{A data frame like \link[r2dii.data:region_isos]{r2dii.data::region_isos} (default).}
 
 \item{use_credit_limit}{Logical vector of length 1. \code{FALSE} defaults to using
 the column \code{loan_size_outstanding}. Set to \code{TRUE} to instead use the column
@@ -89,6 +92,7 @@ if (installed) {
   )
   out
 }
+
 }
 \seealso{
 Other functions to calculate scenario targets: 

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -9,9 +9,9 @@ target_sda(
   data,
   ald,
   co2_intensity_scenario,
-  region_isos = r2dii.data::region_isos,
   use_credit_limit = FALSE,
-  by_company = FALSE
+  by_company = FALSE,
+  region_isos = r2dii.data::region_isos
 )
 }
 \arguments{
@@ -23,8 +23,6 @@ target_sda(
 \item{co2_intensity_scenario}{A scenario data frame like
 \link[r2dii.data:co2_intensity_scenario_demo]{r2dii.data::co2_intensity_scenario_demo}.}
 
-\item{region_isos}{A data frame like \link[r2dii.data:region_isos]{r2dii.data::region_isos} (default).}
-
 \item{use_credit_limit}{Logical vector of length 1. \code{FALSE} defaults to using
 the column \code{loan_size_outstanding}. Set to \code{TRUE} to instead use the column
 \code{loan_size_credit_limit}.}
@@ -32,6 +30,8 @@ the column \code{loan_size_outstanding}. Set to \code{TRUE} to instead use the c
 \item{by_company}{Logical vector of length 1. \code{FALSE} defaults to outputting
 \code{weighted_production_value} at the portfolio-level. Set to \code{TRUE} to output
 \code{weighted_production_value} at the company-level.}
+
+\item{region_isos}{A data frame like \link[r2dii.data:region_isos]{r2dii.data::region_isos} (default).}
 }
 \value{
 A tibble with the CO2 emissions factors attributed to

--- a/tests/testthat/_snaps/target_sda.md
+++ b/tests/testthat/_snaps/target_sda.md
@@ -3,19 +3,19 @@
     Code
       out
     Output
-      # A tibble: 68 x 4
-         sector  year emission_factor_metric emission_factor_value
-         <chr>  <dbl> <chr>                                  <dbl>
-       1 cement  2020 projected                              1    
-       2 cement  2021 projected                              2    
-       3 cement  2022 projected                              3    
-       4 cement  2020 corporate_economy                      1    
-       5 cement  2021 corporate_economy                      2    
-       6 cement  2022 corporate_economy                      3    
-       7 cement  2020 target_b2ds                            1    
-       8 cement  2021 target_b2ds                            0.978
-       9 cement  2022 target_b2ds                            0.956
-      10 cement  2023 target_b2ds                            0.933
+      # A tibble: 68 x 6
+         sector  year region scenario_source emission_factor_metric emission_factor_v~
+         <chr>  <dbl> <chr>  <chr>           <chr>                               <dbl>
+       1 cement  2020 global demo_2020       projected                           1    
+       2 cement  2021 global demo_2020       projected                           2    
+       3 cement  2022 global demo_2020       projected                           3    
+       4 cement  2020 global demo_2020       corporate_economy                   1    
+       5 cement  2021 global demo_2020       corporate_economy                   2    
+       6 cement  2022 global demo_2020       corporate_economy                   3    
+       7 cement  2020 global demo_2020       target_b2ds                         1    
+       8 cement  2021 global demo_2020       target_b2ds                         0.978
+       9 cement  2022 global demo_2020       target_b2ds                         0.956
+      10 cement  2023 global demo_2020       target_b2ds                         0.933
       # ... with 58 more rows
 
 ---
@@ -23,18 +23,18 @@
     Code
       out_company
     Output
-      # A tibble: 68 x 5
-         sector  year name_ald     emission_factor_metric emission_factor_value
-         <chr>  <dbl> <chr>        <chr>                                  <dbl>
-       1 cement  2020 shaanxi auto projected                              1    
-       2 cement  2021 shaanxi auto projected                              2    
-       3 cement  2022 shaanxi auto projected                              3    
-       4 cement  2020 market       corporate_economy                      1    
-       5 cement  2021 market       corporate_economy                      2    
-       6 cement  2022 market       corporate_economy                      3    
-       7 cement  2020 shaanxi auto target_b2ds                            1    
-       8 cement  2021 shaanxi auto target_b2ds                            0.999
-       9 cement  2022 shaanxi auto target_b2ds                            0.997
-      10 cement  2023 <NA>         target_b2ds                           NA    
-      # ... with 58 more rows
+      # A tibble: 68 x 7
+         sector  year region scenario_source name_ald     emission_factor_metric
+         <chr>  <dbl> <chr>  <chr>           <chr>        <chr>                 
+       1 cement  2020 global demo_2020       shaanxi auto projected             
+       2 cement  2021 global demo_2020       shaanxi auto projected             
+       3 cement  2022 global demo_2020       shaanxi auto projected             
+       4 cement  2020 global demo_2020       market       corporate_economy     
+       5 cement  2021 global demo_2020       market       corporate_economy     
+       6 cement  2022 global demo_2020       market       corporate_economy     
+       7 cement  2020 global demo_2020       shaanxi auto target_b2ds           
+       8 cement  2021 global demo_2020       shaanxi auto target_b2ds           
+       9 cement  2022 global demo_2020       shaanxi auto target_b2ds           
+      10 cement  2023 global demo_2020       <NA>         target_b2ds           
+      # ... with 58 more rows, and 1 more variable: emission_factor_value <dbl>
 

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -488,7 +488,7 @@ test_that("w/ known input, outputs `technology_share` as expected (#184, #262)",
     c(0.6875, 0.3125)
   )
 
-  FIXME <- 1e-2  # Do we need 1e-3?
+  FIXME <- 1e-2 # Do we need 1e-3?
   expect_equal(
     out$corporate_economy$technology_share,
     c(0.666, 0.333),
@@ -1356,7 +1356,7 @@ test_that("w/ ald with older years than scenarios, outputs 0 percent change in
   expect_equal(
     initial_out$corporate_economy$percentage_of_initial_production_by_scope,
     0L
-    )
+  )
 
   expect_equal(
     initial_out$projected$percentage_of_initial_production_by_scope,
@@ -1367,5 +1367,4 @@ test_that("w/ ald with older years than scenarios, outputs 0 percent change in
     initial_out$target_sds$percentage_of_initial_production_by_scope,
     0L
   )
-
 })

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -271,7 +271,7 @@ test_that("with no matching data warns", {
 
   bad_scenario <- fake_co2_scenario(sector = "bad")
   expect_warning(
-    target_sda(fake_matched(), fake_ald(), bad_scenario), "no scenario"
+    target_sda(fake_matched(), fake_ald(), bad_scenario, region_isos_demo), "no scenario"
   )
 })
 
@@ -465,6 +465,7 @@ test_that("with multiple plant_location, aggregates production-weighted emission
     ),
     region_isos = region_isos_stable
   ) %>%
+    filter(region == "global") %>%
     split(.$emission_factor_metric)
 
   expect_equal(out$corporate_economy$emission_factor_value, 100)

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -15,7 +15,8 @@ test_that("with fake data outputs known value", {
     co2_intensity_scenario = fake_co2_scenario(
       year = c(2020, 2050),
       emission_factor = c(0.6, 0.2)
-    )
+    ),
+    region_isos = region_isos_stable
   )
 
   expect_snapshot(out)
@@ -34,7 +35,8 @@ test_that("with fake data outputs known value", {
       year = c(2020, 2050),
       emission_factor = c(0.6, 0.2)
     ),
-    by_company = TRUE
+    by_company = TRUE,
+    region_isos = region_isos_stable
   )
 
   expect_snapshot(out_company)
@@ -52,7 +54,8 @@ test_that("outputs is ungrouped", {
     co2_intensity_scenario = fake_co2_scenario(
       emission_factor = c(1, 2),
       year = c(2020, 2050)
-    )
+    ),
+    region_isos = region_isos_stable
   )
   expect_false(dplyr::is_grouped_df(out))
 })
@@ -70,7 +73,8 @@ test_that("warns when input data is grouped", {
       co2_intensity_scenario = fake_co2_scenario(
         emission_factor = c(1, 2),
         year = c(2020, 2050)
-      )
+      ),
+      region_isos = region_isos_stable
     )
   }
 
@@ -138,7 +142,8 @@ test_that("without `sector` throws no error", {
     target_sda(
       without_sector,
       ald = fake_ald(sector = "cement"),
-      co2_intensity_scenario = fake_co2_scenario()
+      co2_intensity_scenario = fake_co2_scenario(),
+      region_isos = region_isos_stable
     )
   )
 })
@@ -162,7 +167,8 @@ test_that("properly weights emissions factors", {
     co2_intensity_scenario = fake_co2_scenario(
       year = c(2020, 2050),
       emission_factor = c(0.6, 0.2)
-    )
+    ),
+    region_isos = region_isos_stable
   )
 
   initial_data <- out %>%
@@ -185,11 +191,19 @@ test_that("outputs expected names", {
     ),
     co2_intensity_scenario = fake_co2_scenario(
       year = c(2020, 2050), emission_factor = c(0.6, 0.2)
-    )
+    ),
+    region_isos = region_isos_stable
   )
 
-  exp <- c("sector", "year", "emission_factor_metric", "emission_factor_value")
-  expect_named(out, exp)
+  expected_names <- c(
+    "sector",
+    "year",
+    "region",
+    "scenario_source",
+    "emission_factor_metric",
+    "emission_factor_value"
+    )
+  expect_named(out, expected_names)
 })
 
 test_that("with known input outputs as expected", {
@@ -210,7 +224,12 @@ test_that("with known input outputs as expected", {
     emission_factor = c(0.5, 0.1, 0.5, 0.4)
   )
 
-  out <- target_sda(matched, ald, co2_intensity_scenario) %>%
+  out <- target_sda(
+    matched,
+    ald,
+    co2_intensity_scenario,
+    region_isos = region_isos_stable
+    ) %>%
     arrange(.data$year) %>%
     split(.$emission_factor_metric)
 
@@ -279,7 +298,8 @@ test_that("with duplicated id_loan weights emission_factor as expected (#160)", 
     target_sda(
       match_result,
       ald,
-      scen
+      scen,
+      region_isos = region_isos_stable
     ) %>%
       filter(year == min(year)),
     class = "unique_ids"
@@ -306,7 +326,8 @@ test_that("with NAs in crucial columns errors with informative message (#146)", 
       target_sda(
         data,
         ald,
-        scen
+        scen,
+        region_isos = region_isos_stable
       )
     )
   }
@@ -331,7 +352,8 @@ test_that("with NAs in crucial columns errors with informative message (#146)", 
       target_sda(
         match_result,
         data,
-        scen
+        scen,
+        region_isos = region_isos_stable
       )
     )
   }
@@ -356,7 +378,8 @@ test_that("with NAs in crucial columns errors with informative message (#146)", 
       target_sda(
         match_result,
         ald,
-        data
+        data,
+        region_isos = region_isos_stable
       )
     )
   }
@@ -397,7 +420,8 @@ test_that("with multiple technologies weights emission_factor as expected (#160)
   out <- target_sda(
     match_result,
     ald,
-    scen
+    scen,
+    region_isos = region_isos_stable
   ) %>%
     filter(year == min(year)) %>%
     split(.$emission_factor_metric)
@@ -418,7 +442,8 @@ test_that("with multiple technologies, aggregates production-weighted emission_f
     ),
     co2_intensity_scenario = fake_co2_scenario(
       year = c(2020, 2050), emission_factor = c(0.6, 0.2)
-    )
+    ),
+    region_isos = region_isos_stable
   ) %>%
     split(.$emission_factor_metric)
 
@@ -437,7 +462,8 @@ test_that("with multiple plant_location, aggregates production-weighted emission
     ),
     co2_intensity_scenario = fake_co2_scenario(
       year = c(2020, 2050), emission_factor = c(0.6, 0.2)
-    )
+    ),
+    region_isos = region_isos_stable
   ) %>%
     split(.$emission_factor_metric)
 
@@ -458,7 +484,8 @@ test_that("filters and warns when input-data has NAs", {
       ),
       co2_intensity_scenario = fake_co2_scenario(
         year = c(2020, 2050), emission_factor = c(0.6, 0.2)
-      )
+      ),
+      region_isos = region_isos_stable
     )
   )
   if (packageVersion("testthat") >= "2.99.0.9000") {
@@ -487,7 +514,8 @@ test_that(
         co2_intensity_scenario = fake_co2_scenario(
           emission_factor = c(1, 2),
           year = c(2020, 2050)
-        )
+        ),
+        region_isos = region_isos_stable
       )
     )
   }
@@ -512,7 +540,11 @@ test_that("with multiple values of `country_of_domicile` outputs the expected
   )
 
   out <- matched %>%
-    target_sda(ald, co2_intensity_scenario_demo) %>%
+    target_sda(
+      ald,
+      co2_intensity_scenario_demo,
+      region_isos = region_isos_stable
+      ) %>%
     split(.$emission_factor_metric)
 
   expect_equal(out$projected$emission_factor_value, 0.5)
@@ -549,13 +581,23 @@ test_that("outputs same target regardless of years present in ald", {
     emission_factor = c(2, 1.9, 1.8, 0.25)
   )
 
-  out_ten_year <- target_sda(matched, ald_ten_year, co2_scenario) %>%
+  out_ten_year <- target_sda(
+    matched,
+    ald_ten_year,
+    co2_scenario,
+    region_isos = region_isos_stable
+    ) %>%
     filter(
       year == 2030,
       emission_factor_metric == "target_b2ds"
     )
 
-  out_thirty_year <- target_sda(matched, ald_thirty_year, co2_scenario) %>%
+  out_thirty_year <- target_sda(
+    matched,
+    ald_thirty_year,
+    co2_scenario,
+    region_isos = region_isos_stable
+    ) %>%
     filter(
       year == 2030,
       emission_factor_metric == "target_b2ds"
@@ -583,7 +625,12 @@ test_that("outputs only sectors present in `co2_intensity_scenario` (#308)", {
     year = c(2025, 2026)
   )
 
-  out <- target_sda(matched, ald, co2_scenario)
+  out <- target_sda(
+    matched,
+    ald,
+    co2_scenario,
+    region_isos = region_isos_stable
+    )
 
   out_sectors <- unique(out$sector)
   scenario_sectors <- unique(co2_scenario$sector)
@@ -610,7 +657,12 @@ test_that("doesn't output NAs if ald and scenario years are misaligned (#307,
     year = c(2023, 2025, 2026)
   )
 
-  out <- target_sda(matched, ald, co2_scenario)
+  out <- target_sda(
+    matched,
+    ald,
+    co2_scenario,
+    region_isos = region_isos_stable
+    )
 
   expect_false(
     any(is.na(out$emission_factor_value))
@@ -629,6 +681,11 @@ test_that("output useful error message when emission_factor is not of type doubl
 
   expect_error(
     class = "crucial_column_wrong_type",
-    target_sda(matched, bad_ald, co2_intensity_scenario)
+    target_sda(
+      matched,
+      bad_ald,
+      co2_intensity_scenario,
+      region_isos = region_isos_stable
+      )
   )
 })

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -271,7 +271,13 @@ test_that("with no matching data warns", {
 
   bad_scenario <- fake_co2_scenario(sector = "bad")
   expect_warning(
-    target_sda(fake_matched(), fake_ald(), bad_scenario, region_isos_demo), "no scenario"
+    target_sda(
+      fake_matched(),
+      fake_ald(),
+      bad_scenario,
+      region_isos = region_isos_demo
+      ),
+    "no scenario"
   )
 })
 

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -202,7 +202,7 @@ test_that("outputs expected names", {
     "scenario_source",
     "emission_factor_metric",
     "emission_factor_value"
-    )
+  )
   expect_named(out, expected_names)
 })
 
@@ -229,7 +229,7 @@ test_that("with known input outputs as expected", {
     ald,
     co2_intensity_scenario,
     region_isos = region_isos_stable
-    ) %>%
+  ) %>%
     arrange(.data$year) %>%
     split(.$emission_factor_metric)
 
@@ -545,7 +545,7 @@ test_that("with multiple values of `country_of_domicile` outputs the expected
       ald,
       co2_intensity_scenario_demo,
       region_isos = region_isos_stable
-      ) %>%
+    ) %>%
     split(.$emission_factor_metric)
 
   expect_equal(out$projected$emission_factor_value, 0.5)
@@ -587,7 +587,7 @@ test_that("outputs same target regardless of years present in ald", {
     ald_ten_year,
     co2_scenario,
     region_isos = region_isos_stable
-    ) %>%
+  ) %>%
     filter(
       year == 2030,
       emission_factor_metric == "target_b2ds"
@@ -598,7 +598,7 @@ test_that("outputs same target regardless of years present in ald", {
     ald_thirty_year,
     co2_scenario,
     region_isos = region_isos_stable
-    ) %>%
+  ) %>%
     filter(
       year == 2030,
       emission_factor_metric == "target_b2ds"
@@ -631,7 +631,7 @@ test_that("outputs only sectors present in `co2_intensity_scenario` (#308)", {
     ald,
     co2_scenario,
     region_isos = region_isos_stable
-    )
+  )
 
   out_sectors <- unique(out$sector)
   scenario_sectors <- unique(co2_scenario$sector)
@@ -663,7 +663,7 @@ test_that("doesn't output NAs if ald and scenario years are misaligned (#307,
     ald,
     co2_scenario,
     region_isos = region_isos_stable
-    )
+  )
 
   expect_false(
     any(is.na(out$emission_factor_value))
@@ -687,6 +687,6 @@ test_that("output useful error message when emission_factor is not of type doubl
       bad_ald,
       co2_intensity_scenario,
       region_isos = region_isos_stable
-      )
+    )
   )
 })


### PR DESCRIPTION
`target_sda()` gains the argument `region_isos`. This will allow for regional granularity in the `SDA` output. 

One unfortunate note: 
* The function signature of `target_market_share` is: 
`target_market_share(data, ald, scenario, region_isos, use_credit_limit, by_company, weight_production)`

unfortunately, since we are adding `region_isos` to the `target_sda` function AFTER publishing the package, we cannot add the parameter in the same place as `target_market_share()`, it must be added as the final parameter (or else we risk breaking users old code). 

ie. the function of `target_sda()` is: 
`target_sda(data, ald, co2_intensity_scenario, use_credit_limit, by_company, region_isos)`
with `region_isos` being the final argument. 

Would love to hear @AlexAxthelm @cjyetman and @maurolepore opinions about this. Obviously it would be much nicer to keep some symmetry between these two functions. 

Closes #323