### PR TITLE
Add `region_isos_demo` to `target_sda` calls in README

### DIFF
--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -33,43 +33,34 @@
 #' @examples
 #' installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
 #'   requireNamespace("r2dii.data", quietly = TRUE)
+#'
 #' if (installed) {
 #'   library(r2dii.match)
 #'   library(r2dii.data)
 #'
-#'   # Example datasets from r2dii.data
 #'   loanbook <- head(loanbook_demo, 150)
 #'   ald <- head(ald_demo, 100)
 #'
-#'   co2_scenario <- co2_intensity_scenario_demo
+#'   matched <- loanbook %>%
+#'     match_name(ald) %>%
+#'     prioritize()
 #'
-#'   # WARNING: Remember to validate matches (see `?prioritize`)
-#'   matched <- prioritize(match_name(loanbook, ald))
+#'   # Calculate targets at portfolio level
+#'   matched %>%
+#'     target_sda(
+#'       ald = ald,
+#'       co2_intensity_scenario = co2_intensity_scenario_demo,
+#'       region_isos = region_isos_demo
+#'     )
 #'
-#'   # You may need to clean your data
-#'   anyNA(ald$emission_factor)
-#'   try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
-#'
-#'   ald2 <- subset(ald, !is.na(emission_factor))
-#'   anyNA(ald2$emission_factor)
-#'
-#'   out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
-#'
-#'   # The output includes the portfolio's actual projected emissions factors, the
-#'   # scenario pathway emissions factors, and the portfolio's target emissions
-#'   # factors.
-#'   out
-#'
-#'   # Split-view by metric
-#'   split(out, out$emission_factor_metric)
-#'
-#'   # Calculate company-level targets
-#'   out <- target_sda(
-#'     matched, ald2,
-#'     co2_intensity_scenario = co2_scenario,
-#'     by_company = TRUE
-#'   )
-#'   out
+#'   # Calculate targets at company level
+#'   matched %>%
+#'     target_sda(
+#'       ald = ald,
+#'       co2_intensity_scenario = co2_intensity_scenario_demo,
+#'       region_isos = region_isos_demo,
+#'       by_company = TRUE
+#'     )
 #' }
 #'
 target_sda <- function(data,

--- a/README.Rmd
+++ b/README.Rmd
@@ -71,7 +71,8 @@ matched <- match_name(loanbook_demo, ald_demo) %>%
 matched %>%
   target_sda(
     ald = ald_demo,
-    co2_intensity_scenario = co2_intensity_scenario_demo
+    co2_intensity_scenario = co2_intensity_scenario_demo,
+    region_isos = region_isos_demo
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,102 +1,106 @@
----
-output: github_document 
----
+
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
-
 
 # r2dii.analysis <img src="man/figures/logo.svg" align="right" width="120" />
 
 <!-- badges: start -->
-[![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
-[![CRAN status](https://www.r-pkg.org/badges/version/r2dii.analysis)](https://CRAN.R-project.org/package=r2dii.analysis)
-[![Codecov test coverage](https://codecov.io/gh/2degreesinvesting/r2dii.analysis/branch/main/graph/badge.svg)](https://codecov.io/gh/2degreesinvesting/r2dii.analysis?branch=main)
+
+[![Lifecycle:
+maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/r2dii.analysis)](https://CRAN.R-project.org/package=r2dii.analysis)
+[![Codecov test
+coverage](https://codecov.io/gh/2degreesinvesting/r2dii.analysis/branch/main/graph/badge.svg)](https://codecov.io/gh/2degreesinvesting/r2dii.analysis?branch=main)
 [![R-CMD-check](https://github.com/2DegreesInvesting/r2dii.analysis/workflows/R-CMD-check/badge.svg)](https://github.com/2DegreesInvesting/r2dii.analysis/actions)
 <!-- badges: end -->
 
-These tools help you to assess if a financial portfolio aligns with climate
-goals. They summarize key metrics attributed to the portfolio (e.g.
-production, emission factors), and calculate targets based on climate
-scenarios. They implement in R the last step of the free software 'PACTA'
-(Paris Agreement Capital Transition Assessment;
-<https://2degrees-investing.org/>). Financial institutions use 'PACTA' to
-study how their capital allocation impacts the climate.
+These tools help you to assess if a financial portfolio aligns with
+climate goals. They summarize key metrics attributed to the portfolio
+(e.g. production, emission factors), and calculate targets based on
+climate scenarios. They implement in R the last step of the free
+software ‘PACTA’ (Paris Agreement Capital Transition Assessment;
+<https://2degrees-investing.org/>). Financial institutions use ‘PACTA’
+to study how their capital allocation impacts the climate.
 
 ## Installation
 
 Install the released version of r2dii.analysis from CRAN with:
 
-```r
+``` r
 install.packages("r2dii.analysis")
 ```
 
 Or install the development version of r2dii.analysis from GitHub with:
 
-```r
+``` r
 # install.packages("devtools")
 devtools::install_github("2DegreesInvesting/r2dii.analysis")
 ```
 
-[How to raise an issue?](https://2degreesinvesting.github.io/posts/2020-06-26-instructions-to-raise-an-issue/)
+[How to raise an
+issue?](https://2degreesinvesting.github.io/posts/2020-06-26-instructions-to-raise-an-issue/)
 
 ## Example
 
-* Use `library()` to attach the packages you need. r2dii.analysis does not depend on the packages r2dii.data and r2dii.match; but we suggest you install them -- with `install.packages(c("r2dii.data", "r2dii.match"))` -- so you can reproduce our examples.
+-   Use `library()` to attach the packages you need. r2dii.analysis does
+    not depend on the packages r2dii.data and r2dii.match; but we
+    suggest you install them – with
+    `install.packages(c("r2dii.data", "r2dii.match"))` – so you can
+    reproduce our examples.
 
-
-```r
+``` r
 library(r2dii.data)
 library(r2dii.match)
 library(r2dii.analysis)
 ```
 
-* Use `r2dii.match::match_name()` to identify matches between your loanbook and the asset level data.
+-   Use `r2dii.match::match_name()` to identify matches between your
+    loanbook and the asset level data.
 
-
-```r
+``` r
 matched <- match_name(loanbook_demo, ald_demo) %>%
   prioritize()
 ```
 
 ### Add Scenario Targets
 
-* Use `target_sda()` to calculate SDA targets of CO2 emissions.
+-   Use `target_sda()` to calculate SDA targets of CO2 emissions.
 
-
-```r
+``` r
 matched %>%
   target_sda(
     ald = ald_demo,
-    co2_intensity_scenario = co2_intensity_scenario_demo
+    co2_intensity_scenario = co2_intensity_scenario_demo,
+    region_isos = region_isos_demo
   )
 #> Warning: Removing ald rows where `emission_factor` is NA
-#> # A tibble: 163 × 4
-#>    sector  year emission_factor_metric emission_factor_value
-#>    <chr>  <dbl> <chr>                                  <dbl>
-#>  1 cement  2013 projected                              0.658
-#>  2 cement  2014 projected                              0.659
-#>  3 cement  2015 projected                              0.660
-#>  4 cement  2016 projected                              0.661
-#>  5 cement  2017 projected                              0.662
-#>  6 cement  2018 projected                              0.662
-#>  7 cement  2019 projected                              0.663
-#>  8 cement  2020 projected                              0.664
-#>  9 cement  2021 projected                              0.665
-#> 10 cement  2022 projected                              0.666
-#> # … with 153 more rows
+#> # A tibble: 293 × 6
+#>    sector  year region         scenario_source emission_factor… emission_factor…
+#>    <chr>  <dbl> <chr>          <chr>           <chr>                       <dbl>
+#>  1 cement  2013 advanced econ… demo_2020       projected                  0.0217
+#>  2 cement  2013 developing as… demo_2020       projected                  0.0606
+#>  3 cement  2013 global         demo_2020       projected                  0.658 
+#>  4 cement  2014 advanced econ… demo_2020       projected                  0.0219
+#>  5 cement  2014 developing as… demo_2020       projected                  0.0604
+#>  6 cement  2014 global         demo_2020       projected                  0.659 
+#>  7 cement  2015 advanced econ… demo_2020       projected                  0.0221
+#>  8 cement  2015 developing as… demo_2020       projected                  0.0603
+#>  9 cement  2015 global         demo_2020       projected                  0.660 
+#> 10 cement  2016 advanced econ… demo_2020       projected                  0.0223
+#> # … with 283 more rows
 ```
 
-* Use `target_market_share` to calculate market-share scenario targets at the portfolio level:
+-   Use `target_market_share` to calculate market-share scenario targets
+    at the portfolio level:
 
-
-```r
+``` r
 matched %>%
   target_market_share(
     ald = ald_demo,
     scenario = scenario_demo_2020,
     region_isos = region_isos_demo
   )
-#> # A tibble: 2,334 × 8
+#> # A tibble: 1,790 × 10
 #>    sector     technology  year region scenario_source metric     production
 #>    <chr>      <chr>      <int> <chr>  <chr>           <chr>           <dbl>
 #>  1 automotive electric    2020 global demo_2020       projected     324592.
@@ -109,13 +113,13 @@ matched %>%
 #>  8 automotive electric    2021 global demo_2020       target_sps    330435.
 #>  9 automotive electric    2022 global demo_2020       projected     354720.
 #> 10 automotive electric    2022 global demo_2020       target_cps    333693.
-#> # … with 2,324 more rows, and 1 more variable: technology_share <dbl>
+#> # … with 1,780 more rows, and 3 more variables: technology_share <dbl>,
+#> #   scope <chr>, percentage_of_initial_production_by_scope <dbl>
 ```
 
-* Or at the company level:
+-   Or at the company level:
 
-
-```r
+``` r
 matched %>%
   target_market_share(
     ald = ald_demo,
@@ -127,7 +131,7 @@ matched %>%
 #> This will result in company-level results, weighted by the portfolio
 #> loan size, which is rarely useful. Did you mean to set one of these
 #> arguments to `FALSE`?
-#> # A tibble: 32,946 × 9
+#> # A tibble: 32,402 × 11
 #>    sector     technology  year region scenario_source name_ald metric production
 #>    <chr>      <chr>      <int> <chr>  <chr>           <chr>    <chr>       <dbl>
 #>  1 automotive electric    2020 global demo_2020       toyota … proje…    324592.
@@ -140,18 +144,19 @@ matched %>%
 #>  8 automotive electric    2021 global demo_2020       toyota … targe…    330435.
 #>  9 automotive electric    2022 global demo_2020       toyota … proje…    354720.
 #> 10 automotive electric    2022 global demo_2020       toyota … targe…    333693.
-#> # … with 32,936 more rows, and 1 more variable: technology_share <dbl>
+#> # … with 32,392 more rows, and 3 more variables: technology_share <dbl>,
+#> #   scope <chr>, percentage_of_initial_production_by_scope <dbl>
 ```
 
 ### Utility Functions
 
-The `target_*()` functions provide shortcuts for common operations. They wrap some utility functions that you may also use directly:
+The `target_*()` functions provide shortcuts for common operations. They
+wrap some utility functions that you may also use directly:
 
-* Use `join_ald_scenario()` to join a matched dataset to the relevant 
-scenario data, and to pick assets in the relevant regions. 
+-   Use `join_ald_scenario()` to join a matched dataset to the relevant
+    scenario data, and to pick assets in the relevant regions.
 
-
-```r
+``` r
 loanbook_joined_to_ald_scenario <- matched %>%
   join_ald_scenario(
     ald = ald_demo,
@@ -160,11 +165,10 @@ loanbook_joined_to_ald_scenario <- matched %>%
   )
 ```
 
-* Use `summarize_weighted_production()` with different grouping arguments to 
-calculate scenario-targets:
+-   Use `summarize_weighted_production()` with different grouping
+    arguments to calculate scenario-targets:
 
-
-```r
+``` r
 # portfolio level
 loanbook_joined_to_ald_scenario %>%
   summarize_weighted_production(scenario, tmsr, smsp, region)
@@ -203,18 +207,18 @@ loanbook_joined_to_ald_scenario %>%
 #> #   weighted_technology_share <dbl>
 ```
 
-[Get started](https://2degreesinvesting.github.io/r2dii.analysis/articles/r2dii-analysis.html).
-
-
+[Get
+started](https://2degreesinvesting.github.io/r2dii.analysis/articles/r2dii-analysis.html).
 
 ## Funding
 
 This project has received funding from the [European Union LIFE
-program](https://wayback.archive-it.org/12090/20210412123959/https://ec.europa.eu/easme/en/) and the [International Climate
-Initiative
+program](https://wayback.archive-it.org/12090/20210412123959/https://ec.europa.eu/easme/en/)
+and the [International Climate Initiative
 (IKI)](https://www.international-climate-initiative.com/en/details/project/measuring-paris-agreement-alignment-and-financial-risk-in-financial-markets-18_I_351-2982).
-The Federal Ministry for the Environment, Nature Conservation and Nuclear Safety
-(BMU) supports this initiative on the basis of a decision adopted by the German
-Bundestag. The views expressed are the sole responsibility of the authors and do
-not necessarily reflect the views of the funders. The funders are not
-responsible for any use that may be made of the information it contains.
+The Federal Ministry for the Environment, Nature Conservation and
+Nuclear Safety (BMU) supports this initiative on the basis of a decision
+adopted by the German Bundestag. The views expressed are the sole
+responsibility of the authors and do not necessarily reflect the views
+of the funders. The funders are not responsible for any use that may be
+made of the information it contains.

--- a/man/target_sda.Rd
+++ b/man/target_sda.Rd
@@ -52,43 +52,34 @@ This function ignores existing groups and outputs ungrouped data.
 \examples{
 installed <- requireNamespace("r2dii.match", quietly = TRUE) &&
   requireNamespace("r2dii.data", quietly = TRUE)
+
 if (installed) {
   library(r2dii.match)
   library(r2dii.data)
 
-  # Example datasets from r2dii.data
   loanbook <- head(loanbook_demo, 150)
   ald <- head(ald_demo, 100)
 
-  co2_scenario <- co2_intensity_scenario_demo
+  matched <- loanbook \%>\%
+    match_name(ald) \%>\%
+    prioritize()
 
-  # WARNING: Remember to validate matches (see `?prioritize`)
-  matched <- prioritize(match_name(loanbook, ald))
+  # Calculate targets at portfolio level
+  matched \%>\%
+    target_sda(
+      ald = ald,
+      co2_intensity_scenario = co2_intensity_scenario_demo,
+      region_isos = region_isos_demo
+    )
 
-  # You may need to clean your data
-  anyNA(ald$emission_factor)
-  try(target_sda(matched, ald, co2_intensity_scenario = co2_scenario))
-
-  ald2 <- subset(ald, !is.na(emission_factor))
-  anyNA(ald2$emission_factor)
-
-  out <- target_sda(matched, ald2, co2_intensity_scenario = co2_scenario)
-
-  # The output includes the portfolio's actual projected emissions factors, the
-  # scenario pathway emissions factors, and the portfolio's target emissions
-  # factors.
-  out
-
-  # Split-view by metric
-  split(out, out$emission_factor_metric)
-
-  # Calculate company-level targets
-  out <- target_sda(
-    matched, ald2,
-    co2_intensity_scenario = co2_scenario,
-    by_company = TRUE
-  )
-  out
+  # Calculate targets at company level
+  matched \%>\%
+    target_sda(
+      ald = ald,
+      co2_intensity_scenario = co2_intensity_scenario_demo,
+      region_isos = region_isos_demo,
+      by_company = TRUE
+    )
 }
 
 }


### PR DESCRIPTION
Since merging #397, all calls to `target_sda` in `README` and the function documentation lead to 0-row output. 

New argument `region_isos` must be set to `r2dii.data::region_isos_demo` to correctly output data. 