### PR TITLE
In `target_sda`, remove sectors from `co2_intensity_scenario` if missing from `data` and `ald`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # r2dii.analysis (development version)
+* `target_sda()` now only outputs data for `sector` values that are in all three 
+  input datasets (`data`, `ald` and `co2_intensity_scenario`) (#390). 
+
 * `target_sda()` now outputs unweighted `emission_factor` if `by_company` is 
   `TRUE` (#376). 
 

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -166,12 +166,23 @@ target_sda <- function(data,
     return(empty_target_sda_output())
   }
 
-  corporate_economy <- calculate_market_average(ald_by_sector)
+  relevant_ald_by_sector <- ald_by_sector %>%
+    filter(sector %in% unique(data$sector))
+
+  corporate_economy <- calculate_market_average(relevant_ald_by_sector)
 
   interpolate_groups <- c("scenario_source", "scenario", "sector", "region")
 
+  relevant_scenario <- co2_intensity_scenario %>%
+    filter(sector %in% unique(data$sector))
+
+  if (identical(nrow(relevant_scenario), 0L)) {
+    warn("Found no match between loanbook and scenario.", class = "no_match")
+    return(empty_target_sda_output())
+  }
+
   interpolated_scenario <- interpolate_scenario_yearly(
-    co2_intensity_scenario,
+    relevant_scenario,
     !!!rlang::syms(interpolate_groups)
   )
 

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -277,7 +277,7 @@ test_that("with no matching data warns", {
       bad_scenario,
       region_isos = region_isos_stable
       ),
-    "no scenario"
+    class = "no_match"
   )
 })
 

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -275,7 +275,7 @@ test_that("with no matching data warns", {
       fake_matched(),
       fake_ald(),
       bad_scenario,
-      region_isos = region_isos_demo
+      region_isos = region_isos_stable
       ),
     "no scenario"
   )

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -739,3 +739,28 @@ test_that("argument `weight_emission_factor` outputs correctly with known input 
     ald$`boral cement`$emission_factor
   )
 })
+
+test_that("outputs empty tibble for sectors in `scenario` and `ald` but not
+          `data` (#390)", {
+
+  ald <- fake_ald(
+    sector = c("cement", "steel")
+  )
+
+  scenario <- fake_co2_scenario(
+    sector = rep(c("cement", "steel"), each = 2),
+    year = rep(c(2025, 2026), 2),
+    emission_factor = rep(c(1, 2), 2)
+  )
+
+  out <- target_sda(
+    fake_matched(sector_ald = "cement"),
+    ald,
+    scenario,
+    region_isos = region_isos_stable
+  )
+
+  out_steel <- filter(out, sector == "steel")
+
+  expect_equal(nrow(out_steel), 0L)
+})


### PR DESCRIPTION
This is a bit of a hacky PR that ensure that the output of `target_sda` only contains `sectors` that are mutual to all input datasets (`data`, `ald` and `co2_intensity_scenario`). 

These hacks beg for a larger refactor of the function, but I'd rather get this bug fixed ASAP, and deal with the larger function refactor with less urgency. 

Closes #390