### PR TITLE
Remove brittle snapshot test

### DIFF
--- a/tests/testthat/test-summarize_weighted_production.R
+++ b/tests/testthat/test-summarize_weighted_production.R
@@ -185,32 +185,6 @@ test_that("preserves groups passed to ...", {
   expect_equal(dplyr::group_vars(out), "plant_location")
 })
 
-test_that("for production, with demo data returns known value", {
-  allows_reserved_columns <- exists(
-    "allow_reserved_columns",
-    where = asNamespace("r2dii.match"),
-    mode = "function"
-  )
-  skip_if_not(allows_reserved_columns)
-
-  restore <- options(r2dii.match.allow_reserved_columns = TRUE)
-  on.exit(options(restore), add = TRUE)
-
-  master <- prioritize(match_name(loanbook_stable, ald_demo)) %>%
-    join_ald_scenario(
-      ald = ald_demo,
-      scenario = scenario_demo_2020,
-      region_isos = region_isos_stable
-    )
-
-  credit_limit0 <- summarize_weighted_production(master)
-  expect_snapshot(credit_limit0)
-
-  credit_limit1 <- master %>%
-    summarize_weighted_production(use_credit_limit = TRUE)
-  expect_snapshot(credit_limit1)
-})
-
 # Percent-change ---------------------------------------------------------------
 
 test_that("with bad `data` errors with informative message", {


### PR DESCRIPTION
These snapshot tests on `demo` data were added when the package was first written, and are very brittle. 

With [this PR](https://github.com/2DegreesInvesting/r2dii.data/pull/280), those tests will now begin to pass warnings. 

Since the output of `summarize_weight_production` is (indirectly) tested extensively in `target_market_share`, I think it is safe to simply remove this brittle test. 