### PR TITLE
Update `target_*` functions to warn and change `isos` to lower-case in `region_isos`

### DIFF
--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -103,6 +103,8 @@ target_market_share <- function(data,
 
   abcd <- filter_and_warn_na(abcd, "production")
 
+  region_isos <- change_to_lowercase_and_warn(region_isos, "isos")
+
   warn_if_by_company_and_weight_production(by_company, weight_production)
 
   data <- ungroup(warn_grouped(data, "Ungrouping input data."))

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -126,6 +126,8 @@ target_sda <- function(data,
   abcd <- filter_and_warn_na(abcd, "production")
   abcd <- filter_and_warn_na(abcd, "emission_factor")
 
+  region_isos <- change_to_lowercase_and_warn(region_isos, "isos")
+
   walk_(crucial_abcd, ~ check_no_value_is_missing(abcd, .x))
 
   check_crucial_names(co2_intensity_scenario, crucial_scenario)

--- a/R/utils.R
+++ b/R/utils.R
@@ -107,3 +107,18 @@ rename_and_warn_ald_names <- function(data) {
   data
 
 }
+
+change_to_lowercase_and_warn <- function(data, column) {
+  if(any(data[[column]] != tolower(data[[column]]), na.rm = TRUE)) {
+    name_dataset <- deparse(substitute(data))
+    warning_message = paste("The column `{column}` of", name_dataset, "has been updated to only contain lower-cases.")
+    warn(
+      glue(warning_message),
+      class = "column_not_in_lowercase"
+    )
+    data[[column]] <- tolower(data[[column]])
+  }
+
+  return(data)
+
+}

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1395,3 +1395,18 @@ test_that("production column in scenario dataset is removed with a warning #372"
     )
   )
 })
+
+test_that("region_isos only has lowercase isos #398", {
+
+  bad_region_isos <- mutate(region_isos_demo, isos = toupper(isos))
+
+  expect_warning(
+    class = "region_isos_not_lowercase",
+    target_market_share(
+      fake_matched(),
+      fake_abcd(),
+      fake_scenario(),
+      bad_region_isos
+    )
+  )
+})

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1401,7 +1401,7 @@ test_that("region_isos only has lowercase isos #398", {
   bad_region_isos <- mutate(region_isos_demo, isos = toupper(isos))
 
   expect_warning(
-    class = "region_isos_not_lowercase",
+    class = "column_not_in_lowercase",
     target_market_share(
       fake_matched(),
       fake_abcd(),

--- a/tests/testthat/test-target_sda.R
+++ b/tests/testthat/test-target_sda.R
@@ -791,3 +791,18 @@ test_that("outputs empty tibble for sectors in `scenario` and `abcd` but not
 
   expect_equal(nrow(out_steel), 0L)
 })
+
+test_that("region_isos only has lowercase isos #398", {
+
+  bad_region_isos <- mutate(region_isos_demo, isos = toupper(isos))
+
+  expect_warning(
+    class = "column_not_in_lowercase",
+    target_sda(
+      fake_matched(sector_abcd = "cement", "steel"),
+      fake_abcd(sector = c("cement", "steel")),
+      fake_co2_scenario(),
+      region_isos = bad_region_isos
+    )
+  )
+})


### PR DESCRIPTION
In case the input `region_isos` has upper-cases in `isos`, the `target_market_share` and `target_sda` function will call a function to change the upper-cases to lower-cases and will issue a warning to the user. If this is not done, the joining of `region_isos` outputs 0 rows. 

Closes 398.